### PR TITLE
perrorをそっくりそのまま実装。NULL入力等テスト済み。

### DIFF
--- a/lib/ft_perror.c
+++ b/lib/ft_perror.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "libft.h"
+#include "constants.h"
+#include <string.h>
+#include <errno.h>
+
+void		ft_perror(char *str)
+{
+	if (str != NULL && str[0] != '\0')
+	{
+		ft_putstr_fd(str, STD_ERR);
+		ft_putstr_fd(": ", STD_ERR);
+	}
+	ft_putstr_fd(strerror(errno), STD_ERR);
+	ft_putchar_fd('\n', STD_ERR);
+}


### PR DESCRIPTION
#21 
perror実装しました。
入力がNULLか\0の時は   ": "を出力しないので、そこだけ注意して例外処理しました。