### PR TITLE
各々のファイル内でmainを書いて実行できるようにmakefileを改良。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ minishell
 
 *.o
 *.d
+.gdb_history

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-# Makefile ver1.1
+# Makefile ver1.3
 
 NAME = minishell
 SRCS = $(shell find ./src -type f -name "*.c") \
@@ -9,8 +9,9 @@ DEPS = $(OBJS:.o=.d)
 CC = gcc
 CFLAGS = -Wall -Wextra -Werror -I./include
 
+# make debug ARG=READ_CMD_LINE_C　のようにして使う。
 ifdef DEBUG
-CFLAGS += -g -fsanitize=address
+CFLAGS += -g -fsanitize=address -D DEBUG=1 -D $(ARG)=1
 endif
 
 all: $(NAME)

--- a/src/main.c
+++ b/src/main.c
@@ -1,10 +1,15 @@
+#include "read_cmd_line.h"
+
+#ifndef DEBUG
 
 int		main(int argc, char **argv, char **envp)
 {
+	char	line[ARG_MAX];
+
 	setup_signal();
 	while (1)
 	{
-		read_line();
+		read_cmd_line(line);
 		parse_line();
 		create_empty_file(); // open とclose
 		exec_cmd();
@@ -12,4 +17,7 @@ int		main(int argc, char **argv, char **envp)
 		free_line();
 		free_list();
 	}
+	(void)argc; (void)argv; (void)envp;
 }
+
+#endif


### PR DESCRIPTION
例えば、read_cmd_line.cファイルをテストしたいとき、

１）ファイル末尾にこのようにしてテストしたいmainを付け足す。
```c
#ifdef READ_CMD_LINE_C

int main(void)
~~~

#endif
```
２）debugルールでコンパイルし、ARG=READ_CMD_LINE_Cを渡すことで
mainを選んでコンパイルされる。

make debug ARG=READ_CMD_LINE_C
