### PR TITLE
read_cmd_line関数の実装（プロンプト未対応）（Rnakai/create read cmd line func）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CFLAGS = -Wall -Wextra -Werror -I./include -g
 
 # make debug ARG=READ_CMD_LINE_C　のようにして使う。
 ifdef DEBUG
-CFLAGS += -fsanitize=address -D DEBUG=1 -D $(ARG)=1
+CFLAGS += -D DEBUG=1 -D $(ARG)=1 #-fsanitize=address
 endif
 
 all: $(NAME)

--- a/include/constants.h
+++ b/include/constants.h
@@ -1,15 +1,18 @@
 #ifndef CONSTANTS_H
 # define CONSTANTS_H
 
+/*
+** define true and false below
+*/
+
+# include "struct/t_bool.h"
+
 # define STD_IN 0
 # define STD_OUT 1
 # define STD_ERR 2
 
-# define TRUE 1
-# define FALSE 0
-
 # define ERROR -1
 
-# define BUFFER_SIZE 1000
+# define ARG_MAX 262144 //guacamolle でgetconf ARG_MAX
 
 #endif

--- a/include/read_cmd_line.h
+++ b/include/read_cmd_line.h
@@ -1,0 +1,6 @@
+#ifndef READ_CMD_LINE_H
+#define READ_CMD_LINE_H
+
+int		read_cmd_line(char *line);
+
+#endif

--- a/include/struct/t_bool.h
+++ b/include/struct/t_bool.h
@@ -1,0 +1,10 @@
+#ifndef T_BOOL_H
+#define T_BOOL_H
+
+typedef enum
+{
+	FALSE = 0,
+	TRUE = 1
+}	t_bool;
+
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -4,6 +4,7 @@
 #include "struct/env_list.h"
 
 void		ft_perror(char *str);
+void		putchar_times_fd(char ch, int times, int fd);
 
 t_env_list *make_new_env_node(char *envp_i);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,10 +1,11 @@
-// #include "read_cmd_line.h"
+#include "read_cmd_line.h"
+#include "constants.h"
 
 #ifndef DEBUG
 
 int		main(int argc, char **argv, char **envp)
 {
-	char	line[ARG_MAX];
+	char	line[ARG_MAX + 1];
 
 	setup_signal();
 	while (1)

--- a/src/read_cmd_line.c
+++ b/src/read_cmd_line.c
@@ -1,0 +1,85 @@
+#include <unistd.h>
+#include "constants.h"
+#include <stdlib.h>
+#include "libft.h"
+#include "read_cmd_line.h"
+#include "utils.h"
+
+static t_bool	is_there_endl(char *line)
+{
+	if (ft_strchr(line, '\n'))
+		return (TRUE);
+	return (FALSE);
+}
+
+static void		reput_line_has_read(char *line, int size_has_read)
+{
+	putchar_times_fd('\b', size_has_read, STD_OUT);
+	ft_putstr_fd(line, STD_OUT);
+}
+
+static int		read_cmd_line_recursive(char *line, int size_has_read)
+{
+	int		actual_read_size;
+
+	reput_line_has_read(line, size_has_read); //TODO: コンソールのプロンプト、bash>などは未対応
+	actual_read_size =
+		read(STD_IN, &line[size_has_read], ARG_MAX - size_has_read);
+	if (actual_read_size < 0)
+	{
+		ft_perror("minishell");
+		return (ERROR);
+	}
+	else if (actual_read_size == ARG_MAX - size_has_read)
+	{
+		ft_putstr_fd(
+			"minishell: Input reached maximum size(ARG_MAX)\n", STD_ERR);
+		return (ERROR);
+	}
+	//もし改行が含まれてなかったら、つまりctrl-Dが入力されたら
+	if (!is_there_endl(line))
+	{
+		read_cmd_line_recursive(line, ft_strlen(line));
+	}
+	return (0);
+}
+
+int		read_cmd_line(char *line)
+{
+	int		actual_read_size;
+
+	ft_bzero(line, ARG_MAX + 1);
+	actual_read_size = read(STD_IN, line, ARG_MAX);
+	if (line[0] == '\0')
+		exit(1);		//TODO: exitコードは最後のコマンドの終了値、つまり$?が入る
+	else if (actual_read_size < 0)
+	{
+		ft_perror("minishell");
+		return (ERROR);
+	}
+	else if (actual_read_size == ARG_MAX)
+	{
+		// dump_remained_input(); //エラー処理必要なし //REVIEW: 余裕があれば対応
+		//余分に読んでいる部分を吸収する
+		ft_putstr_fd(
+			"minishell: Input reached maximum size(ARG_MAX)\n", STD_ERR);
+		return (ERROR);
+	}
+	//もし改行が含まれてなかったら、つまりctrl-Dが入力されたら
+	if (!is_there_endl(line))
+	{
+		read_cmd_line_recursive(line, ft_strlen(line));
+	}
+	return (0);
+}
+
+#ifdef READ_CMD_LINE_C
+
+int main(void)
+{
+	char line[ARG_MAX + 1];
+	read_cmd_line(line);
+	ft_putstr_fd(line, STD_OUT);
+}
+
+#endif

--- a/src/read_cmd_line.c
+++ b/src/read_cmd_line.c
@@ -12,20 +12,13 @@ static t_bool	is_there_endl(char *line)
 	return (FALSE);
 }
 
-static void		reput_line_has_read(char *line, int size_has_read)
-{
-	putchar_times_fd('\b', size_has_read, STD_OUT);
-	ft_putstr_fd(line, STD_OUT);
-}
-
 static int		read_cmd_line_recursive(char *line, int size_has_read)
 {
 	int		actual_read_size;
 
-	reput_line_has_read(line, size_has_read); //TODO: コンソールのプロンプト、bash>などは未対応
 	actual_read_size =
 		read(STD_IN, &line[size_has_read], ARG_MAX - size_has_read);
-	if (actual_read_size < 0)
+	if (actual_read_size == ERROR)
 	{
 		ft_perror("minishell");
 		return (ERROR);
@@ -52,7 +45,7 @@ int		read_cmd_line(char *line)
 	actual_read_size = read(STD_IN, line, ARG_MAX);
 	if (line[0] == '\0')
 		exit(1);		//TODO: exitコードは最後のコマンドの終了値、つまり$?が入る
-	else if (actual_read_size < 0)
+	else if (actual_read_size == ERROR)
 	{
 		ft_perror("minishell");
 		return (ERROR);

--- a/src/utils/putchar_times_fd.c
+++ b/src/utils/putchar_times_fd.c
@@ -1,0 +1,13 @@
+#include "libft.h"
+
+void	putchar_times_fd(char ch, int times, int fd)
+{
+	int		i;
+
+	i = 0;
+	while (i < times)
+	{
+		ft_putchar_fd(ch, fd);
+		i++;
+	}
+}


### PR DESCRIPTION
read_cmd_line関数を実装しました。
ユーザーから入力を受け取って、lineに入力文字を入れ、parseに渡して処理できるようにするための関数です。

make debug ARG=READ_CMD_LINE_C

でテストできます。

打った文字がそっくりそのまま返ってくればテスト終了です。
また、Ctrl-Dが押されたときの動作も疑似的に再現しています。

## マイナーチェンジ
・t_bool型をenumで定義し、TRUE, FALSEはそこで定数として定義するようにしました。
constants.hにはstruct/t_bool.hをインクルードしているので今までと同じように使えます。
・特定の1文字を繰り返し入力するputchar_times関数を実装しました。utilsディレクトリにあります。


## 残る問題点
~~・現状では、プロンプトなしで入力を受け取っている前提です。
プロンプトを含めて表示する場合、再度対応する必要があります。~~
reput_line_has_read関数を削除することで対応できました。

・ARG_MAXをあふれた場合、あふれた分のコマンドが次のコンソールに送られてしまいます。
ここまで対応をやるのは、余裕があったら、ということにしました。