### PR TITLE
env_listの番兵の修正

### DIFF
--- a/src/env/create_env_list.c
+++ b/src/env/create_env_list.c
@@ -9,8 +9,8 @@ static void init_env_list(void)
 	g_env_list = malloc(sizeof(t_env_list));	// TODO:mallocエラー処理
 	g_env_list->key = NULL;
 	g_env_list->value = NULL;
-	g_env_list->prev = NULL;
-	g_env_list->next = NULL;
+	g_env_list->prev = g_env_list;
+	g_env_list->next = g_env_list;
 }
 
 void create_env_list(char **envp)


### PR DESCRIPTION
例えば、

```c
t_env_list *nil = g_env_list;
g_env_list = g_env_list->next;
while (g_env_list != nil)
{
  ～～
 g_env_list = g_env_list->next;
}

```

g_env_listのイテレートするとき、g_env_listが番兵になるまで回すと思います。
もし、要素が１つもなかったらセグフォになってしまうので修正しました。

ちなみに、この初期化の方法はアルゴリズムの本にも書いてあります。