### PR TITLE
Rnakai/create free procs and gen simple procs funcs

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -4,5 +4,6 @@
 
 void		show_string_arr(char **strings);
 void		show_procs(t_process **procs);
+t_process	**generate_simple_procs(char *line);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,7 +9,8 @@ void		putchar_times_fd(char ch, int times, int fd);
 int			count_string_arr_row(char **strings);
 void		free_string_arr(char **strings);
 void		pendl(void);
-int	count_procs(t_process *procs);
+int			count_procs(t_process *procs);
+void		free_procs(t_process **procs);
 
 t_env_list *make_new_env_node(char *envp_i);
 

--- a/src/debug/generate_simple_procs.c
+++ b/src/debug/generate_simple_procs.c
@@ -1,0 +1,63 @@
+#include "constants.h"
+#include "libft.h"
+#include "struct/process.h"
+#include <stdlib.h>
+#include "utils.h"
+
+static void		cut_last_endl(char *line)
+{
+	char	*endl_ptr;
+
+	endl_ptr = ft_strchr(line, '\n');
+	if (endl_ptr)
+		*endl_ptr = '\0';
+}
+
+t_process		**generate_simple_procs(char *line)
+{
+	char		**semicolon_splitted;
+	char		**pipe_spilitted;
+	t_process	**procs;
+	int			i;
+	int			j;
+
+	cut_last_endl(line);
+	semicolon_splitted = ft_split(line, ';'); //should free TODO: error処理
+	//ここでプロセス行数がわかるので、行数分+1 malloc
+	procs = (t_process**)ft_calloc(sizeof(t_process*),
+		(count_string_arr_row(semicolon_splitted) + 1)); //TODO:error処理
+	
+	i = 0;
+	while (semicolon_splitted[i])
+	{
+		pipe_spilitted = ft_split(semicolon_splitted[i], '|'); //should free TODO:error処理
+		//ここで各プロセス列数がわかるので、各行における列数 + 1 malloc
+		procs[i] = (t_process*)ft_calloc(sizeof(t_process),
+			(count_string_arr_row(pipe_spilitted) + 1)); //TODO:error処理
+		j = 0;
+		while (pipe_spilitted[j])
+		{
+			// ここで、既に二次元配列になったコマンドラインが取得できる
+			procs[i][j].cmd = ft_split(pipe_spilitted[j], ' '); //should free TODO:error処理
+			j++;
+		}
+		free_string_arr(pipe_spilitted);
+		procs[i][j].is_end = TRUE;
+		i++;
+	}
+	free_string_arr(semicolon_splitted);
+	return (procs);
+}
+
+#ifdef GENERATE_SIMPLE_PROCS_C
+
+#include "debug.h"
+int		main(void)
+{
+	t_process	**procs;
+
+	procs = generate_simple_procs("cat -e  aa  jfdk | echo aaa bb   dd | eee; hoge ; ajfsdla ; afda");
+	show_procs(procs);
+}
+
+#endif

--- a/src/utils/free_procs.c
+++ b/src/utils/free_procs.c
@@ -1,0 +1,44 @@
+#include "struct/process.h"
+#include "constants.h"
+#include "utils.h"
+#include <stdlib.h>
+
+void		free_procs(t_process **procs)
+{
+	int		i;
+	int		j;
+
+	i = 0;
+	while (procs[i])
+	{
+		j = 0;
+		while (procs[i][j].is_end != TRUE)
+		{
+			free_string_arr(procs[i][j].cmd);
+			free(procs[i][j].red_in_file_name);
+			free(procs[i][j].red_out_file_name);
+			j++;
+		}
+		free(procs[i]);
+		i++;
+	}
+	free(procs);
+}
+
+#ifdef FREE_PROCS_C
+
+#include "debug.h"
+#include "parse.h"
+int		main(void)
+{
+	t_process	**procs;
+	int			status;
+
+	procs = parse_cmd_line("cat -e  aa  jfdk | echo aaa bb   dd | eee; hoge ; ajfsdla ; afda", &status);
+	(void)status;
+	(void)procs;
+	show_procs(procs);
+	free_procs(procs);
+}
+
+#endif


### PR DESCRIPTION
procsをfreeする関数と、現在のparse_cmd_lineとほぼ一緒（引数だけ違う）generate_simple_procs関数を追加しました。
free_procsはvalgrindでメモリリークチェックしました。


```
==2406== HEAP SUMMARY:
==2406==     in use at exit: 0 bytes in 0 blocks
==2406==   total heap usage: 49 allocs, 49 frees, 992 bytes allocated
==2406==
==2406== All heap blocks were freed -- no leaks are possible
==2406==
==2406== For counts of detected and suppressed errors, rerun with: -v
==2406== Use --track-origins=yes to see where uninitialised values come from
==2406== ERROR SUMMARY: 11 errors from 3 contexts (suppressed: 0 from 0)
```


parse_cmd_lineは仕様変更するので大幅に変わりますが、
簡単なprocsを作って実験するのに便利なので、
別名のgenerate_simple_procs関数として残しました。