### PR TITLE
Yyabumot/fix memleak at create env list func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,9 @@ NAME = minishell
 #SRCS += の形式でディレクトリを追加。コメントアウトで特定ディレクトリ除外可能
 SRCS  = $(shell find ./src -maxdepth 1 -type f -name "*.c")
 SRCS += $(shell find ./src/builtins -type f -name "*.c")
-# SRCS += $(shell find ./src/env -type f -name "*.c")
+SRCS += $(shell find ./src/env -type f -name "*.c")
 SRCS += $(shell find ./src/utils -type f -name "*.c")
-# SRCS += $(shell find ./src/exec_cmd -type f -name "*.c")
-SRCS += ./src/exec_cmd/exec_pipes.c	# TODO: exex_cmdディレクトリ内のファイルがコンパイルできるなら消す
-SRCS += ./src/exec_cmd/exec_cmd.c	# TODO: 上と同様
+SRCS += $(shell find ./src/exec_cmd -type f -name "*.c")
 SRCS += $(shell find ./src/parse -type f -name "*.c")
 SRCS += $(shell find ./src/debug -type f -name "*.c")
 

--- a/src/env/make_new_env_node.c
+++ b/src/env/make_new_env_node.c
@@ -26,7 +26,7 @@ t_env_list *make_new_env_node(char *raw_env_var)
 int main(void)
 {
 	t_env_list *new;
-	char *test_env = "foo=foo";
+	char test_env[] = "foo=foo";
 
 	new = make_new_env_node(test_env);
 	printf("key:%s\n", new->key);

--- a/src/env/make_new_env_node.c
+++ b/src/env/make_new_env_node.c
@@ -5,13 +5,17 @@
 t_env_list *make_new_env_node(char *raw_env_var)
 {
 	t_env_list *new;
-	char **splitted;
+	char *equal_ptr;
+	char *key_ptr;
+	char *val_ptr;
 
 	new = malloc(sizeof(t_env_list));	// TODO:mallocエラー処理
-	splitted = ft_split(raw_env_var, '=');	// TODO:エラー処理
-	new->key = splitted[0];
-	new->value = splitted[1];
-	free(splitted);
+	key_ptr = raw_env_var;
+	equal_ptr = ft_strchr(raw_env_var, '=');	// TODO:エラー処理
+	*equal_ptr = '\0';
+	val_ptr = equal_ptr + 1;
+	new->key = ft_strdup(key_ptr);	// TODO?エラー処理
+	new->value = ft_strdup(val_ptr);	// TODO:エラー処理
 	return new;
 }
 


### PR DESCRIPTION
make_new_env_node関数におけるメモリリーク修正しました

以前の仕様
'='でsplit

変更後
最初の'='の前をkeyに，その後ろをvalueにそれぞれstrdup