### PR TITLE
メタ文字を、クォートやバクスラがあったとき文字として認識するよう調整した　Rnakai/upgrade parse to handle meta char

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -5,5 +5,6 @@
 void		show_string_arr(char **strings);
 void		show_procs(t_process **procs);
 t_process	**generate_simple_procs(char *line);
+void		show_str_procs(char ***str_procs);
 
 #endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -3,6 +3,6 @@
 
 #include "struct/process.h"
 
-t_process		**parse_cmd_line(char *line, int *status);
+char		***parse_cmd_line(char *line);
 
 #endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -3,6 +3,6 @@
 
 #include "struct/process.h"
 
-char		***parse_cmd_line(char *line);
+char		***convert_line2str_procs(char *line);
 
 #endif

--- a/include/parse.h
+++ b/include/parse.h
@@ -1,8 +1,11 @@
 #ifndef PARSE_H
-#define PARSE_H
+# define PARSE_H
 
-#include "struct/process.h"
+# include "struct/process.h"
+
+# define DIVIDER -3
 
 char		***convert_line2str_procs(char *line);
+void		replace_meta_with_divider(char *line, char rplced_ch);
 
 #endif

--- a/src/debug/show_str_procs.c
+++ b/src/debug/show_str_procs.c
@@ -1,0 +1,15 @@
+#include "utils.h"
+#include "debug.h"
+
+void		show_str_procs(char ***str_procs)
+{
+	int		i;
+
+	i = 0;
+	while (str_procs[i])
+	{
+		show_string_arr(str_procs[i]);
+		pendl();
+		i++;
+	}
+}

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,7 @@ int		main(void)
 	{
 		print_prompt();
 		read_cmd_line(line);
-		procs = parse_cmd_line(line, &status);
+		procs = convert_line2str_procs(line, &status);
 		show_procs(procs);
 	}
 }

--- a/src/parse/convert_line2str_procs.c
+++ b/src/parse/convert_line2str_procs.c
@@ -3,6 +3,7 @@
 #include "struct/process.h"
 #include <stdlib.h>
 #include "utils.h"
+#include "parse.h"
 
 static void		cut_last_endl(char *line)
 {
@@ -21,15 +22,16 @@ char		***convert_line2str_procs(char *line)
 	int			i;
 
 	cut_last_endl(line);
-	semicolon_splitted = ft_split(line, ';'); //should free TODO: error処理
+	replace_meta_with_divider(line, ';');
+	semicolon_splitted = ft_split(line, DIVIDER); //should free TODO: error処理
 	//ここでプロセス行数がわかるので、行数分+1 malloc
 	str_procs = (char***)ft_calloc(sizeof(char**),
 		(count_string_arr_row(semicolon_splitted) + 1)); //TODO:error処理
-
 	i = 0;
 	while (semicolon_splitted[i])
 	{
-		pipe_spilitted = ft_split(semicolon_splitted[i], '|'); //should free TODO:error処理
+		replace_meta_with_divider(semicolon_splitted[i], '|');
+		pipe_spilitted = ft_split(semicolon_splitted[i], DIVIDER); //TODO:error処理
 		str_procs[i] = pipe_spilitted;
 		i++;
 	}
@@ -38,18 +40,33 @@ char		***convert_line2str_procs(char *line)
 }
 
 
-#ifdef PARSE_CMD_LINE_C
+#ifdef CONVERT_LINE2STR_PROCS_C
 
 //TODO:メモリリーク解消
 #include <stdio.h>
 #include "debug.h"
-int		main(void)
+
+static void	p_test(char *line, int i)
 {
 	char		***str_procs;
-	char		*line = "cmd | cmd1 | cmd 2 ; echo | echo ; hello";
 
 	str_procs = convert_line2str_procs(line);
+	printf("line%d\n", i);
 	show_str_procs(str_procs);
+	printf("=======================\n");
+}
+
+int		main(void)
+{
+	char		line0[] = "cmd | cmd1 | cmd 2 ; echo | echo ; hello";
+	char		line1[] = "cmd \";\" \"|\"| cmd1 \";\" | ";
+	char		line2[] = "cmd \\; aaa; bbb \\|\\; | cc; a";
+	char		line3[] = "cmd ';;' aa | cmd1 '|''|' | cmd 2 'a;' ; echo | echo ; hello";
+
+	p_test(line0, 0);
+	p_test(line1, 1);
+	p_test(line2, 2);
+	p_test(line3, 3);
 }
 
 #endif

--- a/src/parse/convert_line2str_procs.c
+++ b/src/parse/convert_line2str_procs.c
@@ -13,7 +13,7 @@ static void		cut_last_endl(char *line)
 		*endl_ptr = '\0';
 }
 
-char		***parse_cmd_line(char *line)
+char		***convert_line2str_procs(char *line)
 {
 	char		**semicolon_splitted;
 	char		**pipe_spilitted;
@@ -48,7 +48,7 @@ int		main(void)
 	char		***str_procs;
 	char		*line = "cmd | cmd1 | cmd 2 ; echo | echo ; hello";
 
-	str_procs = parse_cmd_line(line);
+	str_procs = convert_line2str_procs(line);
 	show_str_procs(str_procs);
 }
 

--- a/src/parse/parse_cmd_line.c
+++ b/src/parse/parse_cmd_line.c
@@ -13,42 +13,30 @@ static void		cut_last_endl(char *line)
 		*endl_ptr = '\0';
 }
 
-t_process		**parse_cmd_line(char *line, int *status)
+char		***parse_cmd_line(char *line)
 {
 	char		**semicolon_splitted;
 	char		**pipe_spilitted;
-	t_process	**procs;
+	char		***str_procs;
 	int			i;
-	int			j;
 
 	cut_last_endl(line);
-	*status = SUCCESS;
 	semicolon_splitted = ft_split(line, ';'); //should free TODO: error処理
 	//ここでプロセス行数がわかるので、行数分+1 malloc
-	procs = (t_process**)ft_calloc(sizeof(t_process*),
+	str_procs = (char***)ft_calloc(sizeof(char**),
 		(count_string_arr_row(semicolon_splitted) + 1)); //TODO:error処理
-	
+
 	i = 0;
 	while (semicolon_splitted[i])
 	{
 		pipe_spilitted = ft_split(semicolon_splitted[i], '|'); //should free TODO:error処理
-		//ここで各プロセス列数がわかるので、各行における列数 + 1 malloc
-		procs[i] = (t_process*)ft_calloc(sizeof(t_process),
-			(count_string_arr_row(pipe_spilitted) + 1)); //TODO:error処理
-		j = 0;
-		while (pipe_spilitted[j])
-		{
-			// ここで、既に二次元配列になったコマンドラインが取得できる
-			procs[i][j].cmd = ft_split(pipe_spilitted[j], ' '); //should free TODO:error処理
-			j++;
-		}
-		free_string_arr(pipe_spilitted);
-		procs[i][j].is_end = TRUE;
+		str_procs[i] = pipe_spilitted;
 		i++;
 	}
 	free_string_arr(semicolon_splitted);
-	return (procs);
+	return (str_procs);
 }
+
 
 #ifdef PARSE_CMD_LINE_C
 
@@ -57,12 +45,11 @@ t_process		**parse_cmd_line(char *line, int *status)
 #include "debug.h"
 int		main(void)
 {
-	t_process	**procs;
-	int			status;
+	char		***str_procs;
+	char		*line = "cmd | cmd1 | cmd 2 ; echo | echo ; hello";
 
-	procs = parse_cmd_line("cat -e  aa  jfdk | echo aaa bb   dd | eee; hoge ; ajfsdla ; afda", &status);
-	(void)status;
-	show_procs(procs);
+	str_procs = parse_cmd_line(line);
+	show_str_procs(str_procs);
 }
 
 #endif

--- a/src/parse/replace_meta_with_divider.c
+++ b/src/parse/replace_meta_with_divider.c
@@ -1,0 +1,87 @@
+#include "parse.h"
+
+static void	skip_until_end_quote(char *line, int *idx)
+{
+	char	quote;
+
+	quote = line[*idx];
+	(*idx)++;
+	//ヌル文字までにクォートが閉じているかはvalidateで検査するが、一応チェックしておく
+	while (line[*idx] != quote && line[*idx] != '\0')
+		(*idx)++;
+	(*idx)++;
+}
+
+void		replace_meta_with_divider(char *line, char rplced_ch)
+{
+	int		i;
+
+	i = 0;
+	while (line[i])
+	{
+		if (line[i] == '\"' || line[i] == '\'')
+		{
+			skip_until_end_quote(line, &i);
+			continue ;
+		}
+		else if (line[i] == '\\' && line[i + 1] == rplced_ch)
+		{
+			i += 2; //ヌル終端は保証されているのでセグフォしない
+			continue ;
+		}
+		if (line[i] == rplced_ch)
+			line[i] = DIVIDER;
+		i++;
+	}
+}
+
+#ifdef REPLACE_META_WITH_DIVIDER_C
+#include <stdio.h>
+
+static void	test_replace_meta_with_divider(char *line, char rplced_ch)
+{
+	int		i;
+
+	i = 0;
+	while (line[i])
+	{
+		if (line[i] == '\"' || line[i] == '\'')
+		{
+			skip_until_end_quote(line, &i);
+			continue ;
+		}
+		else if (line[i] == '\\' && line[i + 1] == rplced_ch)
+		{
+			i += 2; //ヌル終端は保証されているのでセグフォしない
+			continue ;
+		}
+		if (line[i] == rplced_ch)
+			line[i] = '@'; //非表示文字だと確認できないので変更
+		i++;
+	}
+}
+
+static void	p_test(char *line, int i)
+{
+	printf("line%d: %s\n", i, line);
+	test_replace_meta_with_divider(line, ';');
+	printf("line%d: %s\n", i, line);
+	printf("---------------------\n");
+}
+
+int	main(void)
+{
+	char line0[] = "cmd ; aaa ; bbb ; ccc 'jfka;;a;'a ; hoge\\; ;; ls \"a;a\" ";
+	char line1[] = "cmd ; aaa ; bbb";
+	char line2[] = "hoge 'jfka;;a;'a ; hoge;";
+	char line3[] = "aaa \"hoge;f;oo\", ; a ls; ;a";
+	char line4[] = "aaa;bbb;ccc\\;foo;o";
+
+	p_test(line0, 0);
+	p_test(line1, 1);
+	p_test(line2, 2);
+	p_test(line3, 3);
+	p_test(line4, 4);
+}
+
+#endif


### PR DESCRIPTION
メタ文字　（；｜）が""や''、\があったときに区切り文字として認識しないように調整しました。
yiwasa さんの、一度区切り文字を非表示文字に置き換え、非表示文字でsplitするというアイデアを採用しています。

CONVERT_LINE2STR_PROCS_C
REPLACE_META_WITH_DIVIDER_C
でテストできます。

また、parse_cmd_lineという関数はconvert_line2str_procsという関数名に変更しました。
それに伴い、parse_cmd_lineはt_process型の二次元配列をリターンしていたのに対して、
convert_line2str_procsはchar型の三次元配列（文字列の二次元配列）をリターンする仕様に変更になりました。
これによって多くのparse_cmd_lineを使っていたテストに影響が出ます。
（以前のparse_cmd_lineはgeneraete_simple_procsによって置き換えることができます。）

また、今回の実装では3次元配列をfreeする関数を実装していないので、メモリリークします。
free関数までプルリクに入れるとさすがに大きくなってしまうので、メモリリーク以外の確認をお願いします。