### PR TITLE
クォートのvalidation

### DIFF
--- a/include/validation.h
+++ b/include/validation.h
@@ -11,5 +11,6 @@ t_bool	is_valid_char_code(char *cmd_line);
 t_bool	is_valid_meta(char **cmd_line, t_bool is_redirect);
 t_bool	is_valid_redirect(char **cmd_line, t_bool *is_redirect);
 t_bool	is_valid_meta_and_redirect(char *cmd_line);
+t_bool is_valid_quote(char *cmd_line);
 
 #endif

--- a/src/validation/is_valid_command_line.c
+++ b/src/validation/is_valid_command_line.c
@@ -1,0 +1,13 @@
+#include "validation.h"
+#include "struct/t_bool.h"
+
+t_bool is_valid_command_line(char *cmd_line)
+{
+	if (!is_valid_char_code(cmd_line))
+		return (FALSE);
+	if (!is_valid_meta_and_redirect(cmd_line))
+		return (FALSE);
+	if (!is_valid_quote(cmd_line))
+		return (FALSE);
+	return (TRUE);
+}

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -9,6 +9,7 @@ static t_bool	is_quote(char c)
 
 static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
 {
+	++(*cmd_line);
 	while (TRUE)
 	{
 		if (!(**cmd_line))	// TODO:エラー出力
@@ -16,7 +17,9 @@ static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
 		if (**cmd_line == '\\')
 		{
 			++(*cmd_line);
-			if(**cmd_line == '\"')
+			if (!(**cmd_line))
+				return (FALSE);
+			if (**cmd_line == '\"')
 			{
 				++(*cmd_line);
 				continue;
@@ -35,11 +38,9 @@ t_bool			is_valid_quote(char *cmd_line)
 
 	while (*cmd_line)
 	{
-		kind_of_quote = 0;
 		if(is_quote(*cmd_line))
 		{
 			kind_of_quote = *cmd_line;
-			++cmd_line;
 			if (!is_closed_quote(&cmd_line, kind_of_quote))
 				return (FALSE);
 		}

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -1,0 +1,49 @@
+#include "struct/t_bool.h"
+
+static t_bool	is_quote(char c)
+{
+	if (c == '\'' || c == '\"')
+		return (TRUE);
+	return (FALSE);
+}
+
+static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
+{
+	while (TRUE)
+	{
+		if (!(**cmd_line))	// TODO:エラー出力
+			return (FALSE);
+		if (**cmd_line == '\\')
+		{
+			++(*cmd_line);
+			if(**cmd_line == '\"')
+			{
+				++(*cmd_line);
+				continue;
+			}
+		}
+		if (kind_of_quote == **cmd_line)
+			break;
+		++(*cmd_line);
+	}
+	return (TRUE);
+}
+
+t_bool			is_valid_quote(char *cmd_line)
+{
+	char	kind_of_quote;
+
+	while (*cmd_line)
+	{
+		kind_of_quote = 0;
+		if(is_quote(*cmd_line))
+		{
+			kind_of_quote = *cmd_line;
+			++cmd_line;
+			if (!is_closed_quote(&cmd_line, kind_of_quote))
+				return (FALSE);
+		}
+		++cmd_line;
+	}
+	return (TRUE);
+}

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -28,6 +28,11 @@ int main(void)
 		"echo \"hell\\\"o\"",
 		"echo \"\"",
 		"echo \"hello\'\'world\""
+		"echo \"a\\\"a\" ", //   "a\"a"
+		"echo \'a\\\"a\' ", //   'a\"a'
+		"echo \'a\\\' ", //   'a\'
+		"echo \'a\"a\' ", //   'a"a'
+		"echo \"h\'e\"l\'l\"o\'",
 	};
 
 	char *invalid_cmds[] =
@@ -40,6 +45,9 @@ int main(void)
 		"echo \"h\'e\"l\'l\"o\"",
 		"echo \"\"\"",
 		"echo \"\"\"\"\"\"\""
+		"echo \'a\\\'a\'", //   'a\'a'
+		"echo \'a\\\'\' ", //   'a\''
+		"echo \"\\", //この例だとセグフォする可能性がある
 	};
 
 	ft_putstr_fd("Valid commands ==========\n", STD_OUT);

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -1,3 +1,59 @@
+#ifdef IS_VALID_QUOTE_C
+
+#include <stdlib.h>
+#include "libft.h"
+#include "validation.h"
+#include "constants.h"
+#include "struct/t_bool.h"
+
+static void test_quote(char *cmd_line)
+{
+	t_bool ret_bool;
+
+	ret_bool = is_valid_quote(cmd_line);
+	if(ret_bool == TRUE)
+		ft_putstr_fd("\x1b[32mVALID\x1b[m", STD_OUT);
+	else
+		ft_putstr_fd("\x1b[31mINVALID\x1b[m", STD_OUT);
+	ft_putstr_fd(" : ", STD_OUT);
+	ft_putendl_fd(cmd_line, STD_OUT);
+}
+
+int main(void)
+{
+	char *valid_cmds[] =
+	{
+		"echo \"hello\"",
+		"echo \'hello\'",
+		"echo \"hell\\\"o\"",
+		"echo \"\"",
+		"echo \"hello\'\'world\""
+	};
+
+	char *invalid_cmds[] =
+	{
+		"echo \"hello",
+		"ehco \'hello",
+		"ehco \"hello\'",
+		"echo \'hello\"",
+		"echo \'hell\\\'o\'",
+		"echo \"h\'e\"l\'l\"o\"",
+		"echo \"\"\"",
+		"echo \"\"\"\"\"\"\""
+	};
+
+	ft_putstr_fd("Valid commands ==========\n", STD_OUT);
+	for(size_t i = 0; i < sizeof(valid_cmds) / sizeof(char *); ++i)
+		test_quote(valid_cmds[i]);
+
+	ft_putstr_fd("\nInvalid commands ========\n", STD_OUT);
+	for(size_t i = 0; i < sizeof(invalid_cmds) / sizeof(char *); ++i)
+		test_quote(invalid_cmds[i]);
+}
+
+#endif
+
+
 #ifdef IS_VALID_CHAR_CODE_C
 
 #include "libft.h"


### PR DESCRIPTION
クォートに関するvalidationを実装 (is_validation_quote関数)
IS_VALIDATION_QUOTE_Cでテストできます

is_valid_char_code, is_valid_meta_and_redirect, is_valid_quote関数をまとめて実行するis_valid_command_line関数を実装 (コマンドラインを読んだ後に実行する関数)