### PR TITLE
エラー出力の追加とコメントアウト削除

### DIFF
--- a/src/validation/is_valid_meta.c
+++ b/src/validation/is_valid_meta.c
@@ -25,14 +25,14 @@ t_bool			is_valid_meta(char **cmd_line, t_bool is_redirect)
 	{
 		if (is_meta_following_redirect(is_redirect))
 		{
-			put_syntax_error_message("invalid a metacharacter");
+			put_syntax_error_message("invalid token");
 			return (FALSE);
 		}
 		++(*cmd_line);
 		skip_space(cmd_line);
 		if (is_meta_following_meta(*cmd_line))
 		{
-			put_syntax_error_message("invalid a metacharacter");
+			put_syntax_error_message("invalid token");
 			return (FALSE);
 		}
 	}

--- a/src/validation/is_valid_meta.c
+++ b/src/validation/is_valid_meta.c
@@ -4,7 +4,7 @@
 // リダイレクト後メタ
 static t_bool	is_meta_following_redirect(t_bool is_redirect)
 {
-	if (is_redirect)	// TODO:エラー出力
+	if (is_redirect)
 		return (TRUE);
 	else
 		return (FALSE);
@@ -13,7 +13,7 @@ static t_bool	is_meta_following_redirect(t_bool is_redirect)
 // メタ後メタ
 static t_bool	is_meta_following_meta(char *cmd_line)
 {
-	if (is_meta_char(*cmd_line))	// TODO: エラー出力
+	if (is_meta_char(*cmd_line))
 		return (TRUE);
 	else
 		return (FALSE);
@@ -24,11 +24,17 @@ t_bool			is_valid_meta(char **cmd_line, t_bool is_redirect)
 	if (is_meta_char(**cmd_line))
 	{
 		if (is_meta_following_redirect(is_redirect))
+		{
+			put_syntax_error_message("invalid a metacharacter");
 			return (FALSE);
+		}
 		++(*cmd_line);
 		skip_space(cmd_line);
 		if (is_meta_following_meta(*cmd_line))
+		{
+			put_syntax_error_message("invalid a metacharacter");
 			return (FALSE);
+		}
 	}
 	return (TRUE);
 }

--- a/src/validation/is_valid_meta_and_redirect.c
+++ b/src/validation/is_valid_meta_and_redirect.c
@@ -16,8 +16,11 @@ static void		skip_normal_char(char **cmd_line)
 // 初手メタ
 static t_bool	is_started_with_meta(char *cmd_line)
 {
-	if (is_meta_char(*cmd_line))	// エラー出力
+	if (is_meta_char(*cmd_line))
+	{
+		put_syntax_error_message("invalid a metacharacter");
 		return (TRUE);
+	}
 	else
 		return (FALSE);
 }
@@ -27,7 +30,10 @@ static t_bool	is_started_with_meta(char *cmd_line)
 static t_bool	is_terminated_with_redirect(char *cmd_line, t_bool is_redicrect)
 {
 	if (is_redicrect && !(*cmd_line))	// TODO: エラー出力
+	{
+		put_syntax_error_message("invalid a redirect");
 		return (TRUE);
+	}
 	return (FALSE);
 }
 

--- a/src/validation/is_valid_meta_and_redirect.c
+++ b/src/validation/is_valid_meta_and_redirect.c
@@ -18,7 +18,7 @@ static t_bool	is_started_with_meta(char *cmd_line)
 {
 	if (is_meta_char(*cmd_line))
 	{
-		put_syntax_error_message("invalid a metacharacter");
+		put_syntax_error_message("invalid token");
 		return (TRUE);
 	}
 	else
@@ -31,7 +31,7 @@ static t_bool	is_terminated_with_redirect(char *cmd_line, t_bool is_redicrect)
 {
 	if (is_redicrect && !(*cmd_line))	// TODO: エラー出力
 	{
-		put_syntax_error_message("invalid a redirect");
+		put_syntax_error_message("invalid redirect");
 		return (TRUE);
 	}
 	return (FALSE);

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -1,3 +1,4 @@
+#include "validation.h"
 #include "struct/t_bool.h"
 
 static t_bool	is_quote(char c)
@@ -12,7 +13,7 @@ static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
 	++(*cmd_line);
 	while (TRUE)
 	{
-		if (!(**cmd_line))	// TODO:エラー出力
+		if (!(**cmd_line))
 			return (FALSE);
 		if (**cmd_line == '\\')
 		{
@@ -42,7 +43,10 @@ t_bool			is_valid_quote(char *cmd_line)
 		{
 			kind_of_quote = *cmd_line;
 			if (!is_closed_quote(&cmd_line, kind_of_quote))
+			{
+				put_syntax_error_message("doesn't closed a quotation");
 				return (FALSE);
+			}
 		}
 		++cmd_line;
 	}

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -44,7 +44,7 @@ t_bool			is_valid_quote(char *cmd_line)
 			kind_of_quote = *cmd_line;
 			if (!is_closed_quote(&cmd_line, kind_of_quote))
 			{
-				put_syntax_error_message("doesn't closed a quotation");
+				put_syntax_error_message("quotation is not closed");
 				return (FALSE);
 			}
 		}

--- a/src/validation/is_valid_redirect.c
+++ b/src/validation/is_valid_redirect.c
@@ -24,7 +24,10 @@ t_bool			is_valid_redirect(char **cmd_line, t_bool *is_redirect)
 	{
 		*is_redirect = TRUE;
 		if (!is_single_redirect(cmd_line))
+		{
+			put_syntax_error_message("invalid a redirect");
 			return (FALSE);
+		}
 	}
 	return (TRUE);
 }

--- a/src/validation/is_valid_redirect.c
+++ b/src/validation/is_valid_redirect.c
@@ -25,7 +25,7 @@ t_bool			is_valid_redirect(char **cmd_line, t_bool *is_redirect)
 		*is_redirect = TRUE;
 		if (!is_single_redirect(cmd_line))
 		{
-			put_syntax_error_message("invalid a redirect");
+			put_syntax_error_message("invalid redirect");
 			return (FALSE);
 		}
 	}


### PR DESCRIPTION
放置していたvalidationのエラー出力を実装しました
IS_VALID_META_AND_REDIRECT_C, IS_VALID_CHAR_CODE_C, IS_VALID_QUOTE_Cでテストをして，FAILEDの時にエラーが出力されているかどうか確認してほしいです．