### PR TITLE
コマンド実行系関数の不具合を修正

### DIFF
--- a/src/builtins/exec_builtins.c
+++ b/src/builtins/exec_builtins.c
@@ -33,9 +33,10 @@ void	exec_builtins(char **args)
 	i = 0;
 	while (i < 7)
 	{
-		if (!ft_strcmp(args[0], (char *)g_builtin_func_names[i]))
+		if (!ft_strcmp((char *)g_builtin_func_names[i], args[0]))
 		{
 			g_status = g_builtin_func_ptrs[i](args);
+			return ;
 		}
 		++i;
 	}

--- a/src/env/create_env_list.c
+++ b/src/env/create_env_list.c
@@ -7,6 +7,7 @@
 #include "exit_status.h"
 #include "struct/env_list.h"
 
+extern int g_status;
 extern t_env_list	*g_env_list;
 
 static int	init_env_list(void)
@@ -35,8 +36,9 @@ int			create_env_list(char **envp)
 	{
 		if (!(new = make_new_env_node(envp[i])))
 		{
-			malloc_error();
-			exit(GENERAL_ERRORS);
+			g_status = malloc_error();
+			return (ERROR);
+			// exit(GENERAL_ERRORS);
 		}
 		new->next = g_env_list;
 		g_env_list->prev->next = new;

--- a/src/env/get_env_array.c
+++ b/src/env/get_env_array.c
@@ -22,42 +22,54 @@ static int	count_env_list(void)
 	return (count);
 }
 
-static int	set_env_vars(char **env)
+static char	*make_env_str(t_env_list *env_var)
 {
-	int			i;
-	char		*tmp;
-	t_env_list	*env_var;
+	char	*tmp;
+	char	*env_var_str;
 
-	env_var = g_env_list->next;
-	while (env_var->key)
+	if (!(tmp = ft_strjoin(env_var->key, "=")))
+		return (NULL);
+	if (env_var->value)
 	{
-		if (!(tmp = ft_strjoin(env_var->key, "=")))
-		{
-			env[i] = NULL;
-			free_string_arr(env);
-			return (ERROR);
-		}
-		if (!(env[i] = ft_strjoin(tmp, env_var->value)))
+		if (!(env_var_str = ft_strjoin(tmp, env_var->value)))
 		{
 			free(tmp);
-			free_string_arr(env);
-			return (ERROR);
+			return (NULL);
 		}
-		free(tmp);
-		++i;
-		env_var = env_var->next;
 	}
-	env[i] = NULL;
-	return (SUCCESS);
+	else
+	{
+		if (!(env_var_str = ft_strdup(tmp)))
+		{
+			free(tmp);
+			return (NULL);
+		}
+	}
+	free(tmp);
+	return (env_var_str);
 }
 
 char		**get_env_array(void)
 {
-	char **env;
+	int			i;
+	char		**env;
+	t_env_list	*env_var;
 
 	if (!(env = malloc(sizeof(char *) * (count_env_list() + 1))))
 		return (NULL);
-	if (set_env_vars(env) == ERROR)
-		return (NULL);
+	i = 0;
+	env_var = g_env_list->next;
+	while (env_var->key)
+	{
+		if (!(env[i] = make_env_str(env_var)))
+		{
+			free_string_arr(env);
+			g_status = malloc_error();
+			return (NULL);
+		}
+		++i;
+		env_var = env_var->next;
+	}
+	env[i] = NULL;
 	return (env);
 }

--- a/src/execute/is_builtin_func.c
+++ b/src/execute/is_builtin_func.c
@@ -1,7 +1,7 @@
 #include "utils.h"
 #include "struct/t_bool.h"
 
-extern char **g_builtin_func_names;
+extern const char *g_builtin_func_names[];
 
 t_bool is_builtin_func(char *cmd)
 {
@@ -10,8 +10,9 @@ t_bool is_builtin_func(char *cmd)
 	i = 0;
 	while(i < 7)
 	{
-		if(ft_strcmp(g_builtin_func_names[i], cmd))
+		if(!ft_strcmp((char *)g_builtin_func_names[i], cmd))
 			return (TRUE);
+		++i;
 	}
 	return (FALSE);
 }

--- a/test/cfiles/test_env.c
+++ b/test/cfiles/test_env.c
@@ -41,6 +41,10 @@ int main(int argc, char *argv[], char *envp[])
 
 #ifdef CREATE_ENV_LIST_C
 
+#include <stdio.h>
+
+extern t_env_list *g_env_list;
+
 int	main(int argc, char *argv[], char *envp[])
 {
 	t_env_list *env_node;
@@ -62,6 +66,7 @@ int	main(int argc, char *argv[], char *envp[])
 #ifdef 	MAKE_NEW_ENV_NODE_C
 
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(void)
 {


### PR DESCRIPTION
- get_env_arrayでインデックスを初期化していなかった点を修正
- exec_builtinsでインデックスをインクリメントしてなかった点を修正
- create_env_listでmallocエラーが起きた時にexitしていた点を修正
- is_builtin_funcでg_builtin_func_namesの宣言が不適切だった点を修正
- test_envでテストを行うときに不足していたヘッダーを追加