### PR TITLE
exec_cmds関数でのパイプの不具合を修正

### DIFF
--- a/src/execute/exec_cmds.c
+++ b/src/execute/exec_cmds.c
@@ -95,12 +95,12 @@ void		exec_cmds(t_process *procs)
 			pipe(pipe_fd[i]);
 		if ((pid = fork()) == 0)
 		{
+			close_and_dup_fds_in_child_proc(i, pipe_fd, procs);
 			if (is_builtin_func(procs[i].cmd[0]))
 			{
 				exec_builtins(procs[i].cmd);
 				exit(g_status);
 			}
-			close_and_dup_fds_in_child_proc(i, pipe_fd, procs);
 			my_execve(procs[i].cmd);
 		}
 		else if (i > 0)


### PR DESCRIPTION
#107 
ビルトインコマンドを実行したときにパイプに不具合が起こることを修正しました
具体的には，ビルトインコマンドが実行される前にファイルディスクリプタのcloseやdupするように修正しました