### PR TITLE
validation系関数のNorm適用

### DIFF
--- a/src/validation/is_valid_command_line.c
+++ b/src/validation/is_valid_command_line.c
@@ -1,7 +1,7 @@
 #include "validation.h"
 #include "struct/t_bool.h"
 
-t_bool is_valid_command_line(char *cmd_line)
+t_bool	is_valid_command_line(char *cmd_line)
 {
 	if (!is_valid_char_code(cmd_line))
 		return (FALSE);

--- a/src/validation/is_valid_meta.c
+++ b/src/validation/is_valid_meta.c
@@ -1,7 +1,6 @@
 #include "validation.h"
 #include "struct/t_bool.h"
 
-// リダイレクト後メタ
 static t_bool	is_meta_following_redirect(t_bool is_redirect)
 {
 	if (is_redirect)
@@ -10,7 +9,6 @@ static t_bool	is_meta_following_redirect(t_bool is_redirect)
 		return (FALSE);
 }
 
-// メタ後メタ
 static t_bool	is_meta_following_meta(char *cmd_line)
 {
 	if (is_meta_char(*cmd_line))

--- a/src/validation/is_valid_meta_and_redirect.c
+++ b/src/validation/is_valid_meta_and_redirect.c
@@ -2,18 +2,16 @@
 #include "validation.h"
 #include "struct/t_bool.h"
 
-// 関係ない文字をスキップ
 static void		skip_normal_char(char **cmd_line)
 {
 	while (**cmd_line)
 	{
 		if (is_meta_char(**cmd_line) || is_redirect_char(**cmd_line))
-			break;
+			break ;
 		++(*cmd_line);
 	}
 }
 
-// 初手メタ
 static t_bool	is_started_with_meta(char *cmd_line)
 {
 	if (is_meta_char(*cmd_line))
@@ -25,11 +23,9 @@ static t_bool	is_started_with_meta(char *cmd_line)
 		return (FALSE);
 }
 
-
-// 最後リダイレクト
 static t_bool	is_terminated_with_redirect(char *cmd_line, t_bool is_redicrect)
 {
-	if (is_redicrect && !(*cmd_line))	// TODO: エラー出力
+	if (is_redicrect && !(*cmd_line))
 	{
 		put_syntax_error_message("invalid redirect");
 		return (TRUE);

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -23,11 +23,11 @@ static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
 			if (**cmd_line == '\"')
 			{
 				++(*cmd_line);
-				continue;
+				continue ;
 			}
 		}
 		if (kind_of_quote == **cmd_line)
-			break;
+			break ;
 		++(*cmd_line);
 	}
 	return (TRUE);
@@ -39,7 +39,7 @@ t_bool			is_valid_quote(char *cmd_line)
 
 	while (*cmd_line)
 	{
-		if(is_quote(*cmd_line))
+		if (is_quote(*cmd_line))
 		{
 			kind_of_quote = *cmd_line;
 			if (!is_closed_quote(&cmd_line, kind_of_quote))

--- a/src/validation/is_valid_redirect.c
+++ b/src/validation/is_valid_redirect.c
@@ -1,7 +1,6 @@
 #include "validation.h"
 #include "struct/t_bool.h"
 
-// リダイレクト後リダイレクト
 static t_bool	is_single_redirect(char **cmd_line)
 {
 	if (**cmd_line == '<')
@@ -9,11 +8,11 @@ static t_bool	is_single_redirect(char **cmd_line)
 	else if (**cmd_line == '>')
 	{
 		++(*cmd_line);
-		if(**cmd_line == '>')
+		if (**cmd_line == '>')
 			++(*cmd_line);
 	}
 	skip_space(cmd_line);
-	if(is_redirect_char(**cmd_line))	// TODO:エラー出力
+	if (is_redirect_char(**cmd_line))
 		return (FALSE);
 	return (TRUE);
 }

--- a/src/validation/validation_utils.c
+++ b/src/validation/validation_utils.c
@@ -11,7 +11,6 @@ void			put_syntax_error_message(char *msg)
 	pendl();
 }
 
-
 t_bool			is_meta_char(char c)
 {
 	if (c == '|' || c == ';')


### PR DESCRIPTION
validation系関数にNormを適用しました
コメントアウトを削除したりインデントをそろえたりしただけで，関数の分割などはしてないので大した変更点はありません．