### PR TITLE
Rnakai/fix invalid redirect error bug

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -48,7 +48,7 @@ t_bool		is_escape(char ch);
 
 char		*cut_modifier(char *src);
 char		**cut_all_cmds_modifier(char **raw_cmds);
-int			open_redir_file(char *redir_filename, t_process *redir_config);
+int			open_redir_file(char *redir_filename, t_process *redir_config, t_redir_mode *current_redir);
 void		update_redir_config(t_process *redir_config, char *redir_filename, t_redir_mode *redir_mode);
 int			count_redir_len(char *str_proc, int i, int mode_bit, char *raw_redir_file);
 char		**split_str_by_space(char *str);

--- a/src/parse/redirect/fill_space.c
+++ b/src/parse/redirect/fill_space.c
@@ -4,17 +4,17 @@
 #include "utils.h"
 
 void		fill_space(
-	char *str_proc, int i, t_redir_mode *redir_mode, char *raw_redir)
+	char *str_proc, int i, t_redir_mode *current_redir, char *raw_redir)
 {
 	int		times;
 
 	times = 0;
-	if (redir_mode->fd_str)
+	if (current_redir->fd_str)
 	{
 		i -= 1;
 		times++;
 	}
-	times += (redir_mode->mode_bit & REDIR_APPEND) ? 2 : 1;
+	times += (current_redir->mode_bit & REDIR_APPEND) ? 2 : 1;
 	while (times > 0)
 	{
 		str_proc[i] = ' ';

--- a/src/parse/redirect/open_redir_file.c
+++ b/src/parse/redirect/open_redir_file.c
@@ -1,14 +1,16 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include "constants.h"
+#include "struct/redir_mode.h"
 #include "struct/process.h"
 
-int			open_redir_file(char *redir_filename, t_process *redir_config)
+int			open_redir_file(
+	char *redir_filename, t_process *redir_config, t_redir_mode *current_redir)
 {
 	int		open_flag;
 	int		fd;
 
-	if (redir_config->red_in_file_name)
+	if (current_redir->mode_bit & REDIR_IN)
 	{
 		open_flag = O_RDONLY;
 		fd = open(redir_filename, open_flag);
@@ -17,9 +19,9 @@ int			open_redir_file(char *redir_filename, t_process *redir_config)
 		close(fd);
 		return (SUCCESS);
 	}
-	else if (redir_config->red_out_file_name)
+	else if (current_redir->mode_bit & REDIR_OUT)
 		open_flag = redir_config->red_out_mode;
-	else if (redir_config->red_err_file_name)
+	else if (current_redir->mode_bit & REDIR_ERR)
 		open_flag = redir_config->red_err_mode;
 	fd = open(redir_filename, open_flag, 0644);
 	if (fd == ERROR)

--- a/src/parse/redirect/parse_redirect.c
+++ b/src/parse/redirect/parse_redirect.c
@@ -27,32 +27,32 @@ static int	interpret_as_redir(char *str_proc, int i, t_process *redir_config)
 	char			*raw_redir_file;
 	char			*redir_expanded;
 	char			*redir_filename;
-	t_redir_mode	redir_mode;
+	t_redir_mode	current_redir;
 	int				strlen_has_read;
 
-	detect_redir_mode(str_proc, i, &redir_mode);
-	if (redir_mode.mode_bit & REDIR_BAD_FD)
+	detect_redir_mode(str_proc, i, &current_redir);
+	if (current_redir.mode_bit & REDIR_BAD_FD)
 	{
-		return (p_bad_fd_err(redir_mode.fd_str));
+		return (p_bad_fd_err(current_redir.fd_str));
 	}
-	raw_redir_file = get_redirect_file(str_proc, i, redir_mode.mode_bit); //TODO:
+	raw_redir_file = get_redirect_file(str_proc, i, current_redir.mode_bit); //TODO:
 	redir_expanded = expand_env_var_str(raw_redir_file);
 	if (is_ambiguous_err(redir_expanded))
 	{
 		return (p_ambiguous_err(
-			redir_mode.fd_str, raw_redir_file, redir_expanded));
+			current_redir.fd_str, raw_redir_file, redir_expanded));
 	}
 	redir_filename = cut_modifier(redir_expanded);
-	update_redir_config(redir_config, redir_filename, &redir_mode);
-	if (open_redir_file(redir_filename, redir_config) == ERROR)
+	update_redir_config(redir_config, redir_filename, &current_redir);
+	if (open_redir_file(redir_filename, redir_config, &current_redir) == ERROR)
 	{
-		return (p_open_err(redir_mode.fd_str,
+		return (p_open_err(current_redir.fd_str,
 			raw_redir_file, redir_expanded, redir_config));
 	}
 	strlen_has_read =
-		count_redir_len(str_proc, i, redir_mode.mode_bit, raw_redir_file);
-	fill_space(str_proc, i, &redir_mode, raw_redir_file);
-	free_redir(raw_redir_file, redir_expanded, redir_mode.fd_str);
+		count_redir_len(str_proc, i, current_redir.mode_bit, raw_redir_file);
+	fill_space(str_proc, i, &current_redir, raw_redir_file);
+	free_redir(raw_redir_file, redir_expanded, current_redir.fd_str);
 	return (strlen_has_read);
 }
 

--- a/test/cfiles/test_parse/test_parse_each_task.c
+++ b/test/cfiles/test_parse/test_parse_each_task.c
@@ -18,12 +18,15 @@ int		main(void)
 		" 'echo' 'aaa' ",
 		" echo ' \\af ' ",
 		" echo \" \\af \" ",
-		"\\\\\\\\\\",
+		"\\\\\\\\\\a",
 		" echo hello >test/var_parse/hello",
 		" echo bye >test/var_parse/hello >>test/var_parse/bye",
 		" echo err 2>test/var_parse/err >test/var_parse/stdout <Makefile",
 		" echo err <notexist 2>test/var_parse/err >test/var_parse/stdout <Makefile",
 		" echo err  2>test/var_parse/err >test/var_parse/stdout <notexist <Makefile",
+		" echo err  2>test/var_parse/err >test/var_parse/stdout <notexist <Makefile",
+		"wc < Makefile > ./test/var_parse/test",
+		"wc < Makefile  > ./test/var_parse/test 2>>./test/var_parse/errtest.txt",
 		NULL,
 	};
 	char*	envvar[] = {"export", "foo=bar", "greeting=hello", "hey=good bye", NULL};


### PR DESCRIPTION
```
wc < Makefile > ./test/var_parse/test

cmd:{"echo", "hello"}
redir out fname:[test/var_parse/hello]
stdout mode(OVERWRITE)

minishell: ./test/var_parse/test: No such file or directory
cmd:{"___redirect_failure___"}
```

このようになってしまうエラーを解決しました。
リダイレクト先の空ファイルを作っているとき、標準入力でopenするべきか、空ファイルを作るべきか、という分岐のif文の条件が間違っていたために生じたエラーでした。

また、redir_modeという変数名にしていましたが、
これがredir_configと混同し、現在読んでいるリダイレクトの性質を表すということで、
redir_mode  --> current_redir　に改名しました。
