### PR TITLE
終了ステータスの導出方法を変更

### DIFF
--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -38,7 +38,6 @@ int				my_exit(char **args)
 		ft_putendl_fd(": numeric argument required", STD_ERR);
 		g_status = MISUSE_OF_SHELL_BUILTINS;
 		exit(MISUSE_OF_SHELL_BUILTINS);
-		return (MISUSE_OF_SHELL_BUILTINS);
 	}
 	if (args[1])
 		g_status = ft_atol(args[1]) & 255;

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -7,14 +7,6 @@
 
 extern int g_status;
 
-static long int	ft_abs(long int n)
-{
-	if (n < 0)
-		return (-n);
-	else
-		return (n);
-}
-
 static int		count_digit(char *status)
 {
 	int digit;
@@ -30,32 +22,8 @@ static int		count_digit(char *status)
 	return (digit);
 }
 
-static int		get_exit_status(char **args)
-{
-	int			exit_status;
-	long int	arg_status;
-
-	if (!args[1])
-		exit_status = g_status;
-	else
-	{
-		arg_status = ft_atol(args[1]);
-		if (arg_status < 0)
-		{
-			arg_status = ft_abs(arg_status);
-			exit_status = arg_status % 256;
-			exit_status = 256 - exit_status;
-		}
-		else
-			exit_status = arg_status % 256;
-	}
-	return (exit_status);
-}
-
 int				my_exit(char **args)
 {
-	int	exit_status;
-
 	ft_putendl_fd("exit", STD_ERR);
 	if (2 < count_string_arr_row(args))
 	{
@@ -72,8 +40,7 @@ int				my_exit(char **args)
 		exit(MISUSE_OF_SHELL_BUILTINS);
 		return (MISUSE_OF_SHELL_BUILTINS);
 	}
-	exit_status = get_exit_status(args);
-	g_status = exit_status;
-	exit(exit_status);
-	return (exit_status);
+	if (args[1])
+		g_status = ft_atol(args[1]) & 255;
+	exit(g_status);
 }


### PR DESCRIPTION
#122 関連
今までは自分の勘違いもあって足したり引いたりしてステータスを0-255の範囲にしていました．
確認してみたところ(引数)&255で負の数やlong intにも対応できたので，その方向でステータスを求めるように変更しました．
今までのやり方だと計算が煩雑でバグが起きた時に原因がわかりにくいということもあり修正を入れました．

あと以前にreturnを書かないとコンパイルエラーになると言ったのですが，自分の勘違いでした(ワカモレでも確認しました)．そのためexitの後に書いてあったreturnを消しました