### PR TITLE
ビルトイン関数を実行したときのリダイレクトが無効になっていたので修正

### DIFF
--- a/src/execute/exec_tasks.c
+++ b/src/execute/exec_tasks.c
@@ -19,7 +19,7 @@ static t_bool	should_exec_builtin_func(t_process *procs)
 	return (FALSE);
 }
 
-static void fix_standard_fds(t_process *proc, int fd_stdin, int fd_stdout, int fd_stderr)
+static void reset_standard_fds(t_process *proc, int fd_stdin, int fd_stdout, int fd_stderr)
 {
 	int	fd;
 
@@ -55,7 +55,7 @@ static void exec_single_process_builtin(t_process *proc)
 	fd_stderr = dup(2);
 	close_and_dup_fds_to_redirect(proc);
 	exec_builtins(proc->cmd);
-	fix_standard_fds(proc, fd_stdin, fd_stdout, fd_stderr);
+	reset_standard_fds(proc, fd_stdin, fd_stdout, fd_stderr);
 }
 
 void			exec_tasks(char ***tasks)

--- a/src/execute/exec_tasks.c
+++ b/src/execute/exec_tasks.c
@@ -19,6 +19,45 @@ static t_bool	should_exec_builtin_func(t_process *procs)
 	return (FALSE);
 }
 
+static void fix_standard_fds(t_process *proc, int fd_stdin, int fd_stdout, int fd_stderr)
+{
+	int	fd;
+
+	fd = 255;
+	if (proc->red_in_file_name)
+	{
+		dup2(0, fd);
+		close(fd);
+		dup2(fd_stdin, 0);
+	}
+	if (proc->red_out_file_name)
+	{
+		dup2(1, fd);
+		close(fd);
+		dup2(fd_stdout, 1);
+	}
+	if (proc->red_err_file_name)
+	{
+		dup2(2, fd);
+		close(fd);
+		dup2(fd_stderr, 2);
+	}
+}
+
+static void exec_single_process_builtin(t_process *proc)
+{
+	int	fd_stdin;
+	int	fd_stdout;
+	int	fd_stderr;
+
+	fd_stdin = dup(0);
+	fd_stdout = dup(1);
+	fd_stderr = dup(2);
+	close_and_dup_fds_to_redirect(proc);
+	exec_builtins(proc->cmd);
+	fix_standard_fds(proc, fd_stdin, fd_stdout, fd_stderr);
+}
+
 void			exec_tasks(char ***tasks)
 {
 	int			i;
@@ -34,7 +73,7 @@ void			exec_tasks(char ***tasks)
 			continue;
 		}
 		if (should_exec_builtin_func(procs))
-			exec_builtins(procs[0].cmd);
+			exec_single_process_builtin(&procs[0]);
 		else
 			exec_cmds(procs); //パイプのwhileループ(列のループ)
 		// TODO:free_procs(procs);


### PR DESCRIPTION
ビルトイン関数を実行するときにリダイレクトの処理をするのを忘れていたので実装しました