### PR TITLE
Rnakai/create setup signal func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRCS += $(shell find ./src/parse -type f -name "*.c")
 SRCS += $(shell find ./src/validation -type f -name "*.c")
 SRCS += $(shell find ./src/debug -type f -name "*.c")
 SRCS += $(shell find ./src/main -type f -name "*.c")
+SRCS += $(shell find ./src/signal -type f -name "*.c")
 
 # make debug ARG=READ_CMD_LINE_C　のようにして使う。
 ifdef DEBUG

--- a/include/exit_status.h
+++ b/include/exit_status.h
@@ -8,7 +8,7 @@
 #define COMMAND_CANNOT_EXECUTE 126	// Permission problem or command is not executable
 #define COMMAND_NOT_FOUND 127	// Possible problem with $PATH or a typo
 // #define INVALID_ARG_TO_EXIT 128	// exitに不正な値(浮動小数点など)を渡した
-#define CTRL_C 130
-#define CTRL_BKSLSH 131
+#define STAT_INTERRUPTION 130
+#define STAT_QUIT 131
 
 #endif

--- a/include/main.h
+++ b/include/main.h
@@ -1,5 +1,7 @@
 #ifndef MAIN_H
-#define MAIN_H
+# define MAIN_H
+
+# include "constants.h"
 
 void	print_prompt(void);
 int		p_lack_of_heap_mem_err(void);

--- a/include/setup_signal.h
+++ b/include/setup_signal.h
@@ -1,0 +1,6 @@
+#ifndef SETUP_SIGNAL_H
+#define SETUP_SIGNAL_H
+
+void		setup_signal(void);
+
+#endif

--- a/src/execute/exec_cmds.c
+++ b/src/execute/exec_cmds.c
@@ -19,11 +19,15 @@ static void	wait_child_procs(pid_t last_pid, int count_procs)
 
 	i = 0;
 	waitpid(last_pid, &status, 0);
-	g_status = WEXITSTATUS(status);
-	waitpid(last_pid, &g_status, 0);
+	if (WIFSIGNALED(status))
+		g_status = WTERMSIG(status) + 128;
+	else
+		g_status = WEXITSTATUS(status);
 	while (i < count_procs - 1)
 	{
-		wait(NULL);
+		wait(&status);
+		if (WIFSIGNALED(status))
+			g_status = WTERMSIG(status) + 128;
 		++i;
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,4 @@
-#include "struct/env_list.h"
-#include "exit_status.h"
-
-t_env_list	*g_env_list;
-int			g_status = SUCCEEDED;
-
-#ifndef DEBUG
-
+#include <signal.h>
 #include "read_cmd_line.h"
 #include "constants.h"
 #include "struct/process.h"
@@ -14,6 +7,14 @@ int			g_status = SUCCEEDED;
 #include "main.h"
 #include "execute.h"
 #include <stdlib.h>
+#include "struct/env_list.h"
+#include "exit_status.h"
+
+t_env_list				*g_env_list;
+int						g_status = SUCCEEDED;
+volatile sig_atomic_t	g_is_reading_cmd_line;
+
+#ifndef DEBUG
 
 int		main(int argc, char **argv, char **envp)
 {

--- a/src/main/read_cmd_line.c
+++ b/src/main/read_cmd_line.c
@@ -4,8 +4,10 @@
 #include "libft.h"
 #include "read_cmd_line.h"
 #include "utils.h"
+#include <signal.h>
 
-extern int	g_status;
+extern int						g_status;
+extern volatile sig_atomic_t	g_is_reading_cmd_line;
 
 static t_bool	is_there_endl(char *line)
 {
@@ -18,8 +20,10 @@ static int		read_cmd_line_recursive(char *line, int size_has_read)
 {
 	int		actual_read_size;
 
+	g_is_reading_cmd_line = TRUE;
 	actual_read_size =
 		read(STD_IN, &line[size_has_read], ARG_MAX - size_has_read);
+	g_is_reading_cmd_line = FALSE;
 	if (actual_read_size == ERROR)
 	{
 		ft_perror("minishell");
@@ -44,7 +48,9 @@ int		read_cmd_line(char *line)
 	int		actual_read_size;
 
 	ft_bzero(line, ARG_MAX + 1);
+	g_is_reading_cmd_line = TRUE;
 	actual_read_size = read(STD_IN, line, ARG_MAX);
+	g_is_reading_cmd_line = FALSE;
 	if (line[0] == '\0')
 	{
 		ft_putendl_fd("exit", STD_ERR);
@@ -57,16 +63,11 @@ int		read_cmd_line(char *line)
 	}
 	else if (actual_read_size == ARG_MAX)
 	{
-		// dump_remained_input(); //エラー処理必要なし //REVIEW: 余裕があれば対応
-		//余分に読んでいる部分を吸収する
-		ft_putstr_fd(
-			"minishell: Input reached maximum size(ARG_MAX)\n", STD_ERR);
+		ft_putstr_fd( "minishell: Input reached maximum size.\n", STD_ERR);
 		return (ERROR);
 	}
 	//もし改行が含まれてなかったら、つまりctrl-Dが入力されたら
 	if (!is_there_endl(line))
-	{
 		read_cmd_line_recursive(line, ft_strlen(line));
-	}
 	return (0);
 }

--- a/src/main/setup_shell.c
+++ b/src/main/setup_shell.c
@@ -1,3 +1,4 @@
+#include "setup_signal.h"
 #include "env_ctrl.h"
 #include "exit_status.h"
 #include <stdlib.h>
@@ -12,7 +13,7 @@ void		setup_shell(char **line, char **envp)
 		p_lack_of_heap_mem_err();
 		exit(GENERAL_ERRORS);
 	}
-	// setup_signal();
+	setup_signal();
 	create_env_list(envp);
 
 	(void)envp;

--- a/src/signal/setup_signal.c
+++ b/src/signal/setup_signal.c
@@ -1,0 +1,29 @@
+#include "exit_status.h"
+#include "setup_signal.h"
+#include <signal.h>
+#include "utils.h"
+#include "constants.h"
+#include "libft.h"
+#include "main.h"
+
+extern int g_status;
+
+static void	interrupt_handler(int sig)
+{
+	(void)sig;
+	g_status = STAT_INTERRUPTION;
+	pendl();
+	print_prompt();
+}
+
+static void	quit_handler(int sig)
+{
+	(void)sig;
+	ft_putstr_fd("\b\b  \b\b", STD_OUT);
+}
+
+void		setup_signal(void)
+{
+	signal(SIGINT, interrupt_handler);
+	signal(SIGQUIT, quit_handler);
+}

--- a/src/signal/setup_signal.c
+++ b/src/signal/setup_signal.c
@@ -6,20 +6,31 @@
 #include "libft.h"
 #include "main.h"
 
-extern int g_status;
+extern int						g_status;
+extern volatile sig_atomic_t	g_is_reading_cmd_line;
 
 static void	interrupt_handler(int sig)
 {
-	(void)sig;
-	g_status = STAT_INTERRUPTION;
 	pendl();
-	print_prompt();
+	if (g_is_reading_cmd_line)
+	{
+		print_prompt();
+		g_status = STAT_INTERRUPTION;
+	}
+	(void)sig;
 }
 
 static void	quit_handler(int sig)
 {
+	if (g_is_reading_cmd_line)
+	{
+		ft_putstr_fd("\b\b  \b\b", STD_OUT);
+	}
+	else
+	{
+		ft_putstr_fd("Quit\n", STD_OUT);
+	}
 	(void)sig;
-	ft_putstr_fd("\b\b  \b\b", STD_OUT);
 }
 
 void		setup_signal(void)


### PR DESCRIPTION
・signalディレクトリを追加しました。

・シグナルが動作するようになりました。
read関数の前後に g_is_reading_cmd_lineフラグを挟むことで、シグナルハンドラにコマンド受付中か
コマンド実行中か、の状態を区別できるようにしました。

##残る問題点
シグナルハンドラの中で、非同期呼び出しで安全でない int g_statusの値を変更してしまっています。
g_statusの型を変更する方が好ましいが、全部を変更するとなるとかなりの手間がかかるため、
volatile sig_atomic_t でフラグを用意し、コマンド読み込み後フラグを調査してg_statusを変更する仕様に変更を検討する。