### PR TITLE
Rnakai/fix lack of removing spaces after expand envvar

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -35,6 +35,7 @@ t_bool		should_interpret_as_envvar(char *str, int i);
 
 void		detect_redir_mode(char *str_proc, int i, t_redir_mode *redir_mode);
 char		*get_redirect_file(char *str, int i, int mode_bit);
+char		*extract_redir_fname(t_redir_mode *current_redir, char *raw_redir_fname);
 
 void		skip_space_idx(char *str, int *i);
 void		skip_until_end_single_quote(char *line, int *idx);
@@ -54,7 +55,7 @@ int			count_redir_len(char *str_proc, int i, int mode_bit, char *raw_redir_file)
 char		**split_str_by_space(char *str);
 
 int			p_bad_fd_err(char *fd_str);
-int			p_ambiguous_err(char *str_to_free1, char *str_to_free2, char *redir_expanded);
+int			p_ambiguous_err(char *raw_redir_fname);
 int			p_open_err(char *str_to_free1,
 	char *str_to_free2, char *redir_expanded, t_process *redir_config);
 

--- a/include/parse.h
+++ b/include/parse.h
@@ -54,7 +54,7 @@ void		update_redir_config(t_process *redir_config, char *redir_filename, t_redir
 int			count_redir_len(char *str_proc, int i, int mode_bit, char *raw_redir_file);
 char		**split_str_by_space(char *str);
 
-int			p_bad_fd_err(char *fd_str);
+int			p_bad_fd_err(char *fd_str, t_process *redir_config);
 int			p_ambiguous_err(char *raw_redir_fname);
 int			p_open_err(char *str_to_free1,
 	char *str_to_free2, char *redir_expanded, t_process *redir_config);

--- a/src/execute/exec_tasks.c
+++ b/src/execute/exec_tasks.c
@@ -76,7 +76,7 @@ void			exec_tasks(char ***tasks)
 			exec_single_process_builtin(&procs[0]);
 		else
 			exec_cmds(procs); //パイプのwhileループ(列のループ)
-		// TODO:free_procs(procs);
+		free_procs(procs);
 		++i;
 	}
 }

--- a/src/parse/redirect/extract_redir_fname.c
+++ b/src/parse/redirect/extract_redir_fname.c
@@ -1,0 +1,30 @@
+#include "struct/redir_mode.h"
+#include "libft.h"
+#include "parse.h"
+#include <stdlib.h>
+
+static void	free_three(char *str1, char *str2, char *str3)
+{
+	free(str1);
+	free(str2);
+	free(str3);
+}
+
+char		*extract_redir_fname(t_redir_mode *current_redir, char *raw_redir_fname)
+{
+	char			*redir_expanded;
+	char			*redir_trimmed;
+	char			*redir_filename;
+
+	redir_expanded = expand_env_var_str(raw_redir_fname);
+	redir_trimmed = ft_strtrim(redir_expanded, " \t\n\v\f\r");
+	if (is_ambiguous_err(redir_trimmed))
+	{
+		free_three(redir_expanded, redir_trimmed, current_redir->fd_str);
+		p_ambiguous_err(raw_redir_fname);
+		return (NULL);
+	}
+	redir_filename = cut_modifier(redir_trimmed);
+	free_three(redir_expanded, redir_trimmed, NULL);
+	return (redir_filename);
+}

--- a/src/parse/redirect/p_redir_errs.c
+++ b/src/parse/redirect/p_redir_errs.c
@@ -13,9 +13,10 @@ static void	p_common_err(char *cause, char *msg)
 	ft_putendl_fd(msg, STD_ERR);
 }
 
-int			p_bad_fd_err(char *fd_str)
+int			p_bad_fd_err(char *fd_str, t_process *redir_config)
 {
 	p_common_err(fd_str, "Bad file descriptor");
+	free_single_proc(redir_config);
 	free(fd_str);
 	return (ERROR);
 }

--- a/src/parse/redirect/p_redir_errs.c
+++ b/src/parse/redirect/p_redir_errs.c
@@ -37,7 +37,6 @@ int			p_open_err(char *str_to_free1, char *str_to_free2,
 	ft_perror(NULL);
 	free(str_to_free1);
 	free(str_to_free2);
-	free(redir_filename);
 	free_single_proc(redir_config);
 	return (ERROR);
 }

--- a/src/parse/redirect/p_redir_errs.c
+++ b/src/parse/redirect/p_redir_errs.c
@@ -4,7 +4,6 @@
 #include "constants.h"
 #include "utils.h"
 #include <stdlib.h>
-#include <errno.h>
 
 static void	p_common_err(char *cause, char *msg)
 {
@@ -21,33 +20,23 @@ int			p_bad_fd_err(char *fd_str)
 	return (ERROR);
 }
 
-int			p_ambiguous_err(
-	char *str_to_free1, char *str_to_free2, char *redir_expanded)
+int			p_ambiguous_err(char *raw_redir_fname)
 {
-	p_common_err(redir_expanded, "ambiguous redirect");
-	free(str_to_free1);
-	free(str_to_free2);
-	free(redir_expanded);
+	p_common_err(raw_redir_fname, "ambiguous redirect");
+	free(raw_redir_fname);
 	return (ERROR);
 }
 
 int			p_open_err(char *str_to_free1, char *str_to_free2,
-	char *redir_expanded, t_process *redir_config)
+	char *redir_filename, t_process *redir_config)
 {
-	char	*file_name;
-	int		err_num;
-
-	err_num = errno;
-	file_name = cut_modifier(redir_expanded);
 	ft_putstr_fd("minishell: ", STD_ERR);
-	ft_putstr_fd(file_name, STD_ERR);
+	ft_putstr_fd(redir_filename, STD_ERR);
 	ft_putstr_fd(": ", STD_ERR);
-	errno = err_num;
 	ft_perror(NULL);
 	free(str_to_free1);
 	free(str_to_free2);
-	free(redir_expanded);
-	free(file_name);
+	free(redir_filename);
 	free_single_proc(redir_config);
 	return (ERROR);
 }

--- a/src/parse/redirect/parse_redirect.c
+++ b/src/parse/redirect/parse_redirect.c
@@ -6,11 +6,10 @@
 #include "exit_status.h"
 #include "struct/redir_mode.h"
 
-static void	free_redir(char *str1, char *str2, char *str3)
+static void	free_redir(char *str1, char *str2)
 {
 	free(str1);
 	free(str2);
-	free(str3);
 }
 
 static void	set_redir_config(t_process *proc, t_process *redir_config)
@@ -24,35 +23,29 @@ static void	set_redir_config(t_process *proc, t_process *redir_config)
 
 static int	interpret_as_redir(char *str_proc, int i, t_process *redir_config)
 {
-	char			*raw_redir_file;
-	char			*redir_expanded;
 	char			*redir_filename;
 	t_redir_mode	current_redir;
 	int				strlen_has_read;
+	char			*raw_red_fname;
 
 	detect_redir_mode(str_proc, i, &current_redir);
 	if (current_redir.mode_bit & REDIR_BAD_FD)
-	{
-		return (p_bad_fd_err(current_redir.fd_str));
-	}
-	raw_redir_file = get_redirect_file(str_proc, i, current_redir.mode_bit); //TODO:
-	redir_expanded = expand_env_var_str(raw_redir_file);
-	if (is_ambiguous_err(redir_expanded))
-	{
-		return (p_ambiguous_err(
-			current_redir.fd_str, raw_redir_file, redir_expanded));
-	}
-	redir_filename = cut_modifier(redir_expanded);
+		return (p_bad_fd_err(current_redir.fd_str)); //redir_configのfree
+	raw_red_fname = get_redirect_file(str_proc, i, current_redir.mode_bit); //TODO:
+	redir_filename =
+		extract_redir_fname(&current_redir, raw_red_fname);
+	if (redir_filename == NULL)
+		return (ERROR);//redir_configのfree
+	strlen_has_read =
+		count_redir_len(str_proc, i, current_redir.mode_bit, raw_red_fname);
 	update_redir_config(redir_config, redir_filename, &current_redir);
 	if (open_redir_file(redir_filename, redir_config, &current_redir) == ERROR)
 	{
-		return (p_open_err(current_redir.fd_str,
-			raw_redir_file, redir_expanded, redir_config));
+		return (p_open_err(
+			current_redir.fd_str, raw_red_fname, redir_filename, redir_config));
 	}
-	strlen_has_read =
-		count_redir_len(str_proc, i, current_redir.mode_bit, raw_redir_file);
-	fill_space(str_proc, i, &current_redir, raw_redir_file);
-	free_redir(raw_redir_file, redir_expanded, current_redir.fd_str);
+	fill_space(str_proc, i, &current_redir, raw_red_fname);
+	free_redir(current_redir.fd_str, raw_red_fname);
 	return (strlen_has_read);
 }
 

--- a/src/parse/redirect/parse_redirect.c
+++ b/src/parse/redirect/parse_redirect.c
@@ -5,6 +5,13 @@
 #include "constants.h"
 #include "exit_status.h"
 #include "struct/redir_mode.h"
+#include "utils.h"
+
+static int	return_error_with_free_(t_process *redir_config)
+{
+	free_single_proc(redir_config);
+	return (ERROR);
+}
 
 static void	free_redir(char *str1, char *str2)
 {
@@ -30,12 +37,12 @@ static int	interpret_as_redir(char *str_proc, int i, t_process *redir_config)
 
 	detect_redir_mode(str_proc, i, &current_redir);
 	if (current_redir.mode_bit & REDIR_BAD_FD)
-		return (p_bad_fd_err(current_redir.fd_str)); //redir_configのfree
+		return (p_bad_fd_err(current_redir.fd_str, redir_config)); //redir_configのfree
 	raw_red_fname = get_redirect_file(str_proc, i, current_redir.mode_bit); //TODO:
 	redir_filename =
 		extract_redir_fname(&current_redir, raw_red_fname);
 	if (redir_filename == NULL)
-		return (ERROR);//redir_configのfree
+		return (return_error_with_free_(redir_config));//redir_configのfree
 	strlen_has_read =
 		count_redir_len(str_proc, i, current_redir.mode_bit, raw_red_fname);
 	update_redir_config(redir_config, redir_filename, &current_redir);

--- a/src/parse/utils/is_judge_funcs.c
+++ b/src/parse/utils/is_judge_funcs.c
@@ -13,27 +13,23 @@ t_bool			is_escape(char ch)
 }
 
 //strtrimしてもなお、空白が残っている場合。エスケープあり。
-t_bool			is_ambiguous_err(char *redir_expanded)
+t_bool			is_ambiguous_err(char *redir_trimmed)
 {
-	char	*trimmed;
 	int		i;
 
-	trimmed = ft_strtrim(redir_expanded, " "); //TODO:
 	i = 0;
-	while (trimmed[i])
+	while (redir_trimmed[i])
 	{
-		if (ft_isspace(trimmed[i]))
+		if (ft_isspace(redir_trimmed[i]))
 		{
-			free(trimmed);
 			return (TRUE);
 		}
-		else if (is_escape(trimmed[i]))
+		else if (is_escape(redir_trimmed[i]))
 		{
-			skip_escape_seq(trimmed, &i);
+			skip_escape_seq(redir_trimmed, &i);
 			continue ;
 		}
 		i++;
 	}
-	free(trimmed);
 	return (FALSE);
 }

--- a/test/answer/result/IS_JUDGE_FUNCS_C
+++ b/test/answer/result/IS_JUDGE_FUNCS_C
@@ -7,4 +7,3 @@
 0: result[1]
 1: result[1]
 2: result[1]
-3: result[1]

--- a/test/cfiles/test_parse/test_redirect.c
+++ b/test/cfiles/test_parse/test_redirect.c
@@ -111,18 +111,17 @@ int		main(void)
 int		main(void)
 {
 	char*	correct[] = {
-		"  aaaa  ",
+		"aaaa",
 		"aaa",
 		"\"  hoge  \"",
-		"  ' a a a '  ",
-		"  aa\" \\\" a a \"aa  ",
-		"  aa\\ a\\a\\ a  ",
+		"' a a a '",
+		"aa\" \\\" a a \"aa",
+		"aa\\ a\\a\\ a",
 	};
 	char*	wrong[] = {
 		"a a",
-		"    a a    ",
-		"   a\ta  ",
-		"  \"\" ''",
+		"a\ta",
+		"\"\" ''",
 	};
 	for (unsigned int i = 0; i < sizeof(correct) / sizeof(char*); i++)
 	{

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-all_test_files=`find ./test/cfiles -type f -name "*.c"`
+all_test_files="`find ./test/cfiles -type f -name "*.c"` ./src/main.c"
 ESC=$(printf '\033')
 echo "==================================="
 


### PR DESCRIPTION
## メインの変更

リダイレクト先に空白を含むような環境変数を指定したとき、
空白を含めてリダイレクトファイル名として設定されてしまうバグを矯正しました。

interpret_as_redir関数の中で、最終的なリダイレクト先のfilenameを取得するまでに様々な中間加工文字列が
あったので、極力新しく作ったextract_redir_fname関数に詰めるようにして、freeまで完結できるようにしました。

## その他
・リダイレクト失敗時にメモリリークしていたので、修正しました。

・unit_testがmain.cをtouchしていなかったため、その処理を追加してどんな時でも動作するようにしました。

・コマンド実行後、procsをfreeしていなかったので修正しました。