### PR TITLE
Yyabumot/fix bugs about execute

### DIFF
--- a/src/execute/close_and_dup_fds.c
+++ b/src/execute/close_and_dup_fds.c
@@ -7,6 +7,8 @@ void	close_and_dup_fds_in_child_proc(int i, int **pipe_fd, t_process *procs)
 {
 	if (i == 0)
 	{
+		if (procs[1].is_end == TRUE)
+			return ;
 		dup2(pipe_fd[i][1], 1);
 		close(pipe_fd[i][0]);
 		close(pipe_fd[i][1]);

--- a/src/execute/exec_cmds.c
+++ b/src/execute/exec_cmds.c
@@ -39,6 +39,11 @@ static void	exec_cmd(int i, int **pipe_fd, t_process *procs)
 
 	close_and_dup_fds_in_child_proc(i, pipe_fd, procs);
 	close_and_dup_fds_to_redirect(&(procs[i]));
+	if (!(procs[i].cmd[0]))
+	{
+		g_status = SUCCEEDED;
+		exit(g_status);
+	}
 	if (is_builtin_func(procs[i].cmd[0]))
 	{
 		exec_builtins(procs[i].cmd);
@@ -47,7 +52,7 @@ static void	exec_cmd(int i, int **pipe_fd, t_process *procs)
 	if (!(envp = get_env_array()))
 	{
 		g_status = malloc_error();
-		return ;
+		exit(g_status);
 	}
 	my_execve(procs[i].cmd, envp);
 }

--- a/src/execute/exec_tasks.c
+++ b/src/execute/exec_tasks.c
@@ -4,6 +4,7 @@
 #include "parse.h"
 #include "utils.h"
 #include "execute.h"
+#include "exit_status.h"
 #include "struct/t_bool.h"
 #include "struct/process.h"
 #include "builtins/builtins.h"
@@ -14,6 +15,8 @@ extern volatile sig_atomic_t	g_status;
 static t_bool	should_exec_builtin_func(t_process *procs)
 {
 	if (procs[1].is_end != TRUE)
+		return (FALSE);
+	if (!(procs[0].cmd[0]))
 		return (FALSE);
 	if (is_builtin_func(procs[0].cmd[0]))
 		return (TRUE);


### PR DESCRIPTION
#142 
- 単独のコマンドの時はfdをdupしたりする必要がないので，その点を修正．(これによって./minishellが実行できるようになりました)
- コマンドが空(cmd[0] == NULL)の時にexecveなどをスキップするように修正