### PR TITLE
Yyabumot/fix bugs about validation

### DIFF
--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -8,49 +8,49 @@ static t_bool	is_quote(char c)
 	return (FALSE);
 }
 
-static t_bool	is_closed_quote(char **cmd_line, char kind_of_quote)
+static t_bool	is_closed_quote(int *i, char *cmd_line, char kind_of_quote)
 {
-	++(*cmd_line);
+	++(*i);
 	while (TRUE)
 	{
-		if (!(**cmd_line))
+		if (!(cmd_line[*i]))
 			return (FALSE);
-		if (**cmd_line == '\\')
+		if (cmd_line[*i] == '\\')
 		{
-			++(*cmd_line);
-			if (!(**cmd_line))
+			++(*i);
+			if (!(cmd_line[*i]))
 				return (FALSE);
-			if (**cmd_line == '\"')
+			if (cmd_line[*i] == '\"')
 			{
-				++(*cmd_line);
+				++(*i);
 				continue ;
 			}
 		}
-		if (kind_of_quote == **cmd_line)
+		if (kind_of_quote == cmd_line[*i])
 			break ;
-		++(*cmd_line);
+		++(*i);
 	}
 	return (TRUE);
 }
 
 t_bool			is_valid_quote(char *cmd_line)
 {
+	int		i;
 	char	kind_of_quote;
 
-	while (*cmd_line)
+	i = 0;
+	while (cmd_line[i])
 	{
-		if (*cmd_line == '\\')
-			cmd_line += 2;
-		if (is_quote(*cmd_line))
+		if (is_quote(cmd_line[i]) && 0 < i && cmd_line[i - 1] != '\\')
 		{
-			kind_of_quote = *cmd_line;
-			if (!is_closed_quote(&cmd_line, kind_of_quote))
+			kind_of_quote = cmd_line[i];
+			if (!is_closed_quote(&i, cmd_line, kind_of_quote))
 			{
 				put_syntax_error_message("quotation is not closed");
 				return (FALSE);
 			}
 		}
-		++cmd_line;
+		++i;
 	}
 	return (TRUE);
 }

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -39,6 +39,8 @@ t_bool			is_valid_quote(char *cmd_line)
 
 	while (*cmd_line)
 	{
+		if (*cmd_line == '\\')
+			cmd_line += 2;
 		if (is_quote(*cmd_line))
 		{
 			kind_of_quote = *cmd_line;

--- a/src/validation/is_valid_quote.c
+++ b/src/validation/is_valid_quote.c
@@ -41,8 +41,13 @@ t_bool			is_valid_quote(char *cmd_line)
 	i = 0;
 	while (cmd_line[i])
 	{
-		if (is_quote(cmd_line[i]) && 0 < i && cmd_line[i - 1] != '\\')
+		if (is_quote(cmd_line[i]))
 		{
+			if (0 < i && cmd_line[i - 1] == '\\')
+			{
+				++i;
+				continue ;
+			}
 			kind_of_quote = cmd_line[i];
 			if (!is_closed_quote(&i, cmd_line, kind_of_quote))
 			{

--- a/test/answer/result/IS_VALID_CHAR_CODE_C
+++ b/test/answer/result/IS_VALID_CHAR_CODE_C
@@ -1,0 +1,3 @@
+cmd0: TRUE
+cmd1: minishell: syntax error non-ASCII character
+cmd2: minishell: syntax error non-ASCII character

--- a/test/answer/result/IS_VALID_META_AND_REDIRECT_C
+++ b/test/answer/result/IS_VALID_META_AND_REDIRECT_C
@@ -1,0 +1,83 @@
+Normal commands ===========================
+[32mVALID[m : echo hello | wc
+[32mVALID[m : echo hello > a | wc
+[32mVALID[m : echo hello >> a | wc
+[32mVALID[m : cat < a | wc
+[32mVALID[m : cat < a > b | wc
+[32mVALID[m : cat > a < b | wc
+[32mVALID[m : echo hello > a > b
+[32mVALID[m : echo hello < a < b
+[32mVALID[m : echo hello > a > b > c >> d < e < f
+[32mVALID[m : echo hello > a < b < c > d < e >> f
+[32mVALID[m :    
+[32mVALID[m : 	   
+[32mVALID[m : 
+[32mVALID[m : >a
+
+Start with meta ============================
+minishell: syntax error invalid token
+[31mINVALID[m : | wc
+minishell: syntax error invalid token
+[31mINVALID[m : ; echo hello
+minishell: syntax error invalid token
+[31mINVALID[m :    	; echo hello
+
+Meta following meta ========================
+minishell: syntax error invalid token
+[31mINVALID[m : echo hello |  | wc
+minishell: syntax error invalid token
+[31mINVALID[m : echo hello | ; ls
+minishell: syntax error invalid token
+[31mINVALID[m : echo hello|	;ls
+
+Meta following redirect ====================
+minishell: syntax error invalid token
+[31mINVALID[m : echo hello > |
+minishell: syntax error invalid token
+[31mINVALID[m : echo hello < |
+minishell: syntax error invalid token
+[31mINVALID[m : <|
+
+Exeption redirect ==========================
+minishell: syntax error invalid redirect
+[31mINVALID[m : cat << a
+
+Redirect following redirect ================
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello > > a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello < > a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello > < a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello < < a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello > >> a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello < >> a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >> < a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello << a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello << > a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello > << a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >> << a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >> >> a.txt
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello << << a.txt
+
+Ends with redirect ==========================
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello <
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >>
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello >> a >
+minishell: syntax error invalid redirect
+[31mINVALID[m : echo hello <                    

--- a/test/answer/result/IS_VALID_QUOTE_C
+++ b/test/answer/result/IS_VALID_QUOTE_C
@@ -1,0 +1,32 @@
+Valid commands ==========
+[32mVALID[m : echo "hello"
+[32mVALID[m : echo 'hello'
+[32mVALID[m : echo "hell\"o"
+[32mVALID[m : echo ""
+[32mVALID[m : echo "hello''world"echo "a\"a" 
+[32mVALID[m : echo 'a\"a' 
+[32mVALID[m : echo 'a\' 
+[32mVALID[m : echo 'a"a' 
+[32mVALID[m : echo "h'e"l'l"o'
+
+Invalid commands ========
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo "hello
+minishell: syntax error quotation is not closed
+[31mINVALID[m : ehco 'hello
+minishell: syntax error quotation is not closed
+[31mINVALID[m : ehco "hello'
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo 'hello"
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo 'hell\'o'
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo "h'e"l'l"o"
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo """
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo """""""echo 'a\'a'
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo 'a\'' 
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo "\

--- a/test/answer/result/IS_VALID_QUOTE_C
+++ b/test/answer/result/IS_VALID_QUOTE_C
@@ -8,6 +8,8 @@ Valid commands ==========
 [32mVALID[m : echo 'a\' 
 [32mVALID[m : echo 'a"a' 
 [32mVALID[m : echo "h'e"l'l"o'
+[32mVALID[m :   \"  
+[32mVALID[m :   \'  
 
 Invalid commands ========
 minishell: syntax error quotation is not closed

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -33,6 +33,8 @@ int main(void)
 		"echo \'a\\\' ", //   'a\'
 		"echo \'a\"a\' ", //   'a"a'
 		"echo \"h\'e\"l\'l\"o\'",
+		"  \\\"  ",
+		"  \\\'  ",
 	};
 
 	char *invalid_cmds[] =

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -33,6 +33,7 @@ int main(void)
 		"echo \'a\\\' ", //   'a\'
 		"echo \'a\"a\' ", //   'a"a'
 		"echo \"h\'e\"l\'l\"o\'",
+		"\"echo\" \"hello\"",
 		"  \\\"  ",
 		"  \\\'  ",
 	};
@@ -49,6 +50,7 @@ int main(void)
 		"echo \"\"\"\"\"\"\""
 		"echo \'a\\\'a\'", //   'a\'a'
 		"echo \'a\\\'\' ", //   'a\''
+		"echo \"a",
 		"echo \"\\", //この例だとセグフォする可能性がある
 	};
 

--- a/test/update_result.sh
+++ b/test/update_result.sh
@@ -53,3 +53,6 @@ function update_each_file() {
 # update_each_file CUT_MODIFIER_C
 
 # update_each_file PARSE_EACH_TASK_C
+# update_each_file IS_VALID_QUOTE_C
+# update_each_file IS_VALID_CHAR_CODE_C
+# update_each_file IS_VALID_META_AND_REDIRECT_C

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -70,4 +70,8 @@ test_unit GET_REDIRECT_FILE_C
 test_unit OPEN_REDIR_FILE
 test_unit CUT_MODIFIER_C
 
+test_unit IS_VALID_QUOTE_C
+test_unit IS_VALID_CHAR_CODE_C
+test_unit IS_VALID_META_AND_REDIRECT_C
+
 # test_unit PARSE_EACH_TASK_C #不完全なテストなのでまだ追加しない


### PR DESCRIPTION
```
echo \"
```
のようなコマンドラインの最初に来るクォートがエスケープされている場合がokになっていなかったので修正しました．