### PR TITLE
is_there_execute_file_atがTRUEを返す条件を変更

### DIFF
--- a/src/execute/my_execve.c
+++ b/src/execute/my_execve.c
@@ -20,7 +20,7 @@ static int	is_there_execute_file_at(char *cmd_path)
 	int	fd;
 
 	fd = open(cmd_path, O_WRONLY);
-	return (fd != ERROR || errno != ENOENT);
+	return (fd != ERROR && errno != ENOENT);
 }
 
 static void	check_if_the_full_path_is_valid(char *cmd_path)


### PR DESCRIPTION
#145

my_execveの中のis_there_execute_file_at関数が真偽値を返す条件に誤りがあったので修正しました。
これでcommand not foundが表示されるようになったと思いますので確認をお願いします。