### PR TITLE
Yyabumot/fix bugs about my exit

### DIFF
--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -3,30 +3,37 @@
 #include "utils.h"
 #include "constants.h"
 #include "exit_status.h"
+#include "struct/t_bool.h"
 #include "builtins/my_exit.h"
 #include <signal.h>
 
 extern volatile sig_atomic_t g_status;
 
-static int		count_digit(char *status)
+static int		is_numeric_argument(char *arg)
 {
+	int	i;
 	int digit;
 
+	i = 0;
 	digit = 0;
-	if (*status == '-')
-		++status;
-	while (*status)
+	if (arg[i] == '-' || arg[i] == '+')
+		++i;
+	while (arg[i])
 	{
+		if (arg[i] < '0' || '9' < arg[i])
+			return (FALSE);
 		++digit;
-		++status;
+		++i;
 	}
-	return (digit);
+	if (20 < digit)
+		return (FALSE);
+	return (TRUE);
 }
 
 int				my_exit(char **args)
 {
 	ft_putendl_fd("exit", STD_ERR);
-	if (args[1] && 20 <= count_digit(args[1]))
+	if (args[1] && !is_numeric_argument(args[1]))
 	{
 		ft_putstr_fd("minishell: exit: ", STD_ERR);
 		ft_putstr_fd(args[1], STD_ERR);

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -32,20 +32,27 @@ static int		is_numeric_argument(char *arg)
 
 int				my_exit(char **args)
 {
+	int	i;
+
 	ft_putendl_fd("exit", STD_ERR);
-	if (args[1] && !is_numeric_argument(args[1]))
+	i = 1;
+	while(args[i])
 	{
-		ft_putstr_fd("minishell: exit: ", STD_ERR);
-		ft_putstr_fd(args[1], STD_ERR);
-		ft_putendl_fd(": numeric argument required", STD_ERR);
-		g_status = MISUSE_OF_SHELL_BUILTINS;
-		exit(MISUSE_OF_SHELL_BUILTINS);
-	}
-	if (2 < count_string_arr_row(args))
-	{
-		ft_putendl_fd("minishell: exit: too many arguments\n", STD_ERR);
-		g_status = GENERAL_ERRORS;
-		return (GENERAL_ERRORS);
+		if (1 < i)
+		{
+			ft_putendl_fd("minishell: exit: too many arguments\n", STD_ERR);
+			g_status = GENERAL_ERRORS;
+			return (GENERAL_ERRORS);
+		}
+		if (!is_numeric_argument(args[i]))
+		{
+			ft_putstr_fd("minishell: exit: ", STD_ERR);
+			ft_putstr_fd(args[i], STD_ERR);
+			ft_putendl_fd(": numeric argument required", STD_ERR);
+			g_status = MISUSE_OF_SHELL_BUILTINS;
+			exit(MISUSE_OF_SHELL_BUILTINS);
+		}
+		++i;
 	}
 	if (args[1])
 		g_status = ft_atol(args[1]) & 255;

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -9,7 +9,7 @@
 
 extern volatile sig_atomic_t g_status;
 
-static int		is_numeric_argument(char *arg)
+static t_bool	is_numeric_argument(char *arg)
 {
 	int	i;
 	int digit;
@@ -25,7 +25,7 @@ static int		is_numeric_argument(char *arg)
 		++digit;
 		++i;
 	}
-	if (20 < digit)
+	if (20 <= digit)
 		return (FALSE);
 	return (TRUE);
 }
@@ -36,7 +36,7 @@ int				my_exit(char **args)
 
 	ft_putendl_fd("exit", STD_ERR);
 	i = 1;
-	while(args[i])
+	while (args[i])
 	{
 		if (1 < i)
 		{

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -40,7 +40,7 @@ int				my_exit(char **args)
 	{
 		if (1 < i)
 		{
-			ft_putendl_fd("minishell: exit: too many arguments\n", STD_ERR);
+			ft_putendl_fd("minishell: exit: too many arguments", STD_ERR);
 			g_status = GENERAL_ERRORS;
 			return (GENERAL_ERRORS);
 		}

--- a/test/answer/result/IS_VALID_QUOTE_C
+++ b/test/answer/result/IS_VALID_QUOTE_C
@@ -8,6 +8,7 @@ Valid commands ==========
 [32mVALID[m : echo 'a\' 
 [32mVALID[m : echo 'a"a' 
 [32mVALID[m : echo "h'e"l'l"o'
+[32mVALID[m : "echo" "hello"
 [32mVALID[m :   \"  
 [32mVALID[m :   \'  
 
@@ -30,5 +31,7 @@ minishell: syntax error quotation is not closed
 [31mINVALID[m : echo """""""echo 'a\'a'
 minishell: syntax error quotation is not closed
 [31mINVALID[m : echo 'a\'' 
+minishell: syntax error quotation is not closed
+[31mINVALID[m : echo "a
 minishell: syntax error quotation is not closed
 [31mINVALID[m : echo "\

--- a/test/answer/result/MY_EXIT_C
+++ b/test/answer/result/MY_EXIT_C
@@ -20,21 +20,96 @@ status: 12
 
 6 ==========
 exit
-status: 0
+status: 111
 
 7 ==========
 exit
-status: 199
+status: 0
+
+8 ==========
+exit
+status: 0
+
+9 ==========
+exit
+status: 0
 
 10 ==========
 exit
-minishell: exit: too many arguments
-
-didn't exit
-status: 1
+status: 199
 
 11 ==========
 exit
+status: 57
+
+12 ==========
+exit
+status: 199
+
+20 ==========
+exit
+minishell: exit: too many arguments
+didn't exit
+status: 1
+
+21 ==========
+exit
 minishell: exit: 11111111111111111111: numeric argument required
 status: 2
+
+22 ==========
+exit
+minishell: exit: +11111111111111111111: numeric argument required
+status: 2
+
+23 ==========
+exit
+minishell: exit: -11111111111111111111: numeric argument required
+status: 2
+
+24 ==========
+exit
+minishell: exit: +++0: numeric argument required
+status: 2
+
+25 ==========
+exit
+minishell: exit: +-0: numeric argument required
+status: 2
+
+26 ==========
+exit
+minishell: exit: +-++--+-11111: numeric argument required
+status: 2
+
+27 ==========
+exit
+minishell: exit: a11111: numeric argument required
+status: 2
+
+28 ==========
+exit
+minishell: exit: 11a111: numeric argument required
+status: 2
+
+29 ==========
+exit
+minishell: exit: -11111b: numeric argument required
+status: 2
+
+30 ==========
+exit
+minishell: exit: 111+11: numeric argument required
+status: 2
+
+31 ==========
+exit
+minishell: exit: 111*11: numeric argument required
+status: 2
+
+32 ==========
+exit
+minishell: exit: too many arguments
+didn't exit
+status: 1
 

--- a/test/cfiles/test_builtins.c
+++ b/test/cfiles/test_builtins.c
@@ -121,6 +121,9 @@ int main(void)
 	char *args27[] = {"exit", "a11111", NULL};
 	char *args28[] = {"exit", "11a111", NULL};
 	char *args29[] = {"exit", "-11111b", NULL};
+	char *args30[] = {"exit", "111+11", NULL};
+	char *args31[] = {"exit", "111*11", NULL};
+	char *args32[] = {"exit", "1", "11111111111", NULL};
 
 
 	test_my_exit(args1, 1);
@@ -146,6 +149,9 @@ int main(void)
 	test_my_exit(args27, 27);
 	test_my_exit(args28, 28);
 	test_my_exit(args29, 29);
+	test_my_exit(args30, 30);
+	test_my_exit(args31, 31);
+	test_my_exit(args32, 32);
 }
 
 #endif

--- a/test/cfiles/test_builtins.c
+++ b/test/cfiles/test_builtins.c
@@ -102,11 +102,26 @@ int main(void)
 	char *args3[] = {"exit", "1000", NULL};
 	char *args4[] = {"exit", "-1", NULL};
 	char *args5[] = {"exit", "-500", NULL};
-	char *args6[] = {"exit", NULL};
-	char *args7[] = {"exit", "1111111111111111111", NULL};	// 19ケタ
+	char *args6[] = {"exit", "+111", NULL};
+	char *args7[] = {"exit", "+0", NULL};
+	char *args8[] = {"exit", "-0", NULL};
+	char *args9[] = {"exit", NULL};
+	char *args10[] = {"exit", "1111111111111111111", NULL};	// 19ケタ
+	char *args11[] = {"exit", "-1111111111111111111", NULL};	// 19ケタ
+	char *args12[] = {"exit", "+1111111111111111111", NULL};	// 19ケタ
 
-	char *args10[] = {"exit", "1", "2", "3", NULL};
-	char *args11[] = {"exit", "11111111111111111111", NULL};	// 20ケタ
+
+	char *args20[] = {"exit", "1", "2", "3", NULL};
+	char *args21[] = {"exit", "11111111111111111111", NULL};	// 20ケタ
+	char *args22[] = {"exit", "+11111111111111111111", NULL};	// 20ケタ
+	char *args23[] = {"exit", "-11111111111111111111", NULL};	// 20ケタ
+	char *args24[] = {"exit", "+++0", NULL};
+	char *args25[] = {"exit", "+-0", NULL};
+	char *args26[] = {"exit", "+-++--+-11111", NULL};
+	char *args27[] = {"exit", "a11111", NULL};
+	char *args28[] = {"exit", "11a111", NULL};
+	char *args29[] = {"exit", "-11111b", NULL};
+
 
 	test_my_exit(args1, 1);
 	test_my_exit(args2, 2);
@@ -115,9 +130,22 @@ int main(void)
 	test_my_exit(args5, 5);
 	test_my_exit(args6, 6);
 	test_my_exit(args7, 7);
-
+	test_my_exit(args8, 8);
+	test_my_exit(args9, 9);
 	test_my_exit(args10, 10);
 	test_my_exit(args11, 11);
+	test_my_exit(args12, 12);
+
+	test_my_exit(args20, 20);
+	test_my_exit(args21, 21);
+	test_my_exit(args22, 22);
+	test_my_exit(args23, 23);
+	test_my_exit(args24, 24);
+	test_my_exit(args25, 25);
+	test_my_exit(args26, 26);
+	test_my_exit(args27, 27);
+	test_my_exit(args28, 28);
+	test_my_exit(args29, 29);
 }
 
 #endif


### PR DESCRIPTION
exitのエラー判定を修正しました
- 引数の頭に+が1つあるときをokに修正
- +や-が複数個あるときをエラーとして弾く
- 引数に数字以外が来た時を弾く

エラー判定の優先順位
- 引数が2つ && 1つ目の引数が正常なとき -> too many arguments(プロセスをexitしない)
- 引数が2つ && 1つ目の引数が正常じゃないとき ->numeric argument required(プロセスをexit)