### PR TITLE
Yyabumot/fix command execute terms

### DIFF
--- a/include/execute.h
+++ b/include/execute.h
@@ -15,6 +15,8 @@ void free_pipe_fd_array(int **pipe_fd, t_process *procs);
 int	count_procs(t_process *procs);
 void	if_command_not_found(char *cmd_path);
 char	*join_cmd_to_path(char *cmd, char *path_ptr);
-
+int	is_there_execute_file_at(char *cmd_path);
+void	is_dir(char *cmd_path);
+void	check_if_the_full_path_is_valid(char *cmd_path);
 
 #endif

--- a/include/execute.h
+++ b/include/execute.h
@@ -16,7 +16,7 @@ int	count_procs(t_process *procs);
 void	if_command_not_found(char *cmd_path);
 char	*join_cmd_to_path(char *cmd, char *path_ptr);
 int	is_there_execute_file_at(char *cmd_path);
-void	is_dir(char *cmd_path);
+void	exit_if_command_path_is_dir(char *cmd_path);
 void	check_if_the_full_path_is_valid(char *cmd_path);
 
 #endif

--- a/src/execute/check_command_path.c
+++ b/src/execute/check_command_path.c
@@ -26,7 +26,7 @@ int		is_there_execute_file_at(char *cmd_path)
 	return (TRUE);
 }
 
-void	is_dir(char *cmd_path)
+void	exit_if_command_path_is_dir(char *cmd_path)
 {
 	DIR	*dir;
 

--- a/src/execute/check_command_path.c
+++ b/src/execute/check_command_path.c
@@ -1,0 +1,60 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <stdlib.h>
+#include "libft.h"
+#include "utils.h"
+#include "constants.h"
+#include "exit_status.h"
+
+int	is_there_execute_file_at(char *cmd_path)
+{
+	int	fd;
+
+	if ((fd = open(cmd_path, O_RDONLY)) == ERROR)
+	{
+		if (errno == EACCES)
+		{
+			ft_putstr_fd("minishell: ", STD_ERR);
+			ft_perror(cmd_path);
+			exit(COMMAND_CANNOT_EXECUTE);
+		}
+		return (FALSE);
+	}
+	close(fd);
+	return (TRUE);
+}
+
+void	is_dir(char *cmd_path)
+{
+	DIR	*dir;
+
+	if ((dir = opendir(cmd_path)))
+	{
+		closedir(dir);
+		ft_putstr_fd("minishell: ", STD_ERR);
+		ft_putstr_fd(cmd_path, STD_ERR);
+		ft_putendl_fd(": Is a directory", STD_ERR);
+		exit(COMMAND_CANNOT_EXECUTE);
+	}
+}
+
+void	check_if_the_full_path_is_valid(char *cmd_path)
+{
+	int	fd;
+
+	if ((fd = open(cmd_path, O_RDONLY)) == ERROR)
+	{
+		ft_putstr_fd("minishell: ", STD_ERR);
+		ft_perror(cmd_path);
+		// ft_putstr_fd(cmd_path, STD_ERR);
+		// ft_putstr_fd(": ", STD_ERR);
+		// ft_putendl_fd(strerror(errno), STD_ERR);
+		if (errno == ENOENT || errno == EACCES)
+			exit(COMMAND_NOT_FOUND);
+		else
+			exit(GENERAL_ERRORS);
+	}
+	close(fd);
+}

--- a/src/execute/check_command_path.c
+++ b/src/execute/check_command_path.c
@@ -8,7 +8,7 @@
 #include "constants.h"
 #include "exit_status.h"
 
-int	is_there_execute_file_at(char *cmd_path)
+int		is_there_execute_file_at(char *cmd_path)
 {
 	int	fd;
 
@@ -48,9 +48,6 @@ void	check_if_the_full_path_is_valid(char *cmd_path)
 	{
 		ft_putstr_fd("minishell: ", STD_ERR);
 		ft_perror(cmd_path);
-		// ft_putstr_fd(cmd_path, STD_ERR);
-		// ft_putstr_fd(": ", STD_ERR);
-		// ft_putendl_fd(strerror(errno), STD_ERR);
 		if (errno == ENOENT || errno == EACCES)
 			exit(COMMAND_NOT_FOUND);
 		else

--- a/src/execute/if_command_not_found.c
+++ b/src/execute/if_command_not_found.c
@@ -5,6 +5,7 @@
 
 void	if_command_not_found(char *cmd_path)
 {
+	ft_putstr_fd("minishell: ", STD_ERR);
 	ft_putstr_fd(cmd_path, STD_ERR);
 	ft_putstr_fd(": ", STD_ERR);
 	ft_putendl_fd("command not found", STD_ERR);

--- a/src/execute/my_execve.c
+++ b/src/execute/my_execve.c
@@ -1,4 +1,5 @@
 #include <fcntl.h>
+#include <dirent.h>
 #include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -15,31 +16,6 @@
 
 extern volatile sig_atomic_t g_status;
 extern t_env_list	*g_env_list;
-
-static int	is_there_execute_file_at(char *cmd_path)
-{
-	int	fd;
-
-	fd = open(cmd_path, O_WRONLY);
-	return (fd != ERROR && errno != ENOENT);
-}
-
-static void	check_if_the_full_path_is_valid(char *cmd_path)
-{
-	if (open(cmd_path, O_RDWR) == ERROR && (errno == EISDIR || errno == ENOENT))
-	{
-		ft_putstr_fd("minishell: ", STD_ERR);
-		ft_putstr_fd(cmd_path, STD_ERR);
-		ft_putstr_fd(": ", STD_ERR);
-		ft_putendl_fd(strerror(errno), STD_ERR);
-		if (errno == EISDIR)
-			exit(COMMAND_CANNOT_EXECUTE);
-		else if (errno == ENOENT)
-			exit(COMMAND_NOT_FOUND);
-		else
-			exit(GENERAL_ERRORS);
-	}
-}
 
 static void	do_execve(char *cmd_path, char **cmd, char **envp)
 {
@@ -86,6 +62,7 @@ void		my_execve(char **cmd, char **envp)
 {
 	char *cmd_path;
 
+	is_dir(cmd[0]);
 	if (cmd[0][0] == '/')
 		check_if_the_full_path_is_valid(cmd[0]);
 	if (is_there_execute_file_at(cmd[0]))

--- a/src/execute/my_execve.c
+++ b/src/execute/my_execve.c
@@ -62,7 +62,7 @@ void		my_execve(char **cmd, char **envp)
 {
 	char *cmd_path;
 
-	is_dir(cmd[0]);
+	exit_if_command_path_is_dir(cmd[0]);
 	if (cmd[0][0] == '/')
 		check_if_the_full_path_is_valid(cmd[0]);
 	if (is_there_execute_file_at(cmd[0]))

--- a/test/answer/result/CHECK_EXIT_STATUS_OF_MY_EXECVE_C
+++ b/test/answer/result/CHECK_EXIT_STATUS_OF_MY_EXECVE_C
@@ -29,10 +29,10 @@ minishell: /bin/: Is a directory
 status:126
 =====================
 minishell: /root/a: Permission denied
-status:126
+status:127
 =====================
 minishell: /not/exist: No such file or directory
 status:127
 =====================
-notexist: command not found
+minishell: notexist: command not found
 status:127

--- a/test/answer/result/MY_EXECVE_C
+++ b/test/answer/result/MY_EXECVE_C
@@ -23,4 +23,4 @@ unit_test.sh
 minishell: /bin/: Is a directory
 minishell: /root/a: Permission denied
 minishell: /not/exist: No such file or directory
-notexist: command not found
+minishell: notexist: command not found


### PR DESCRIPTION
#153 を参考に...
- 指定されたcommand pathの判定をする関数の修正
- command not foundの終了ステータスが間違っていたので修正(126 -> 127)
- command not foundのエラー出力を修正(macのbashで行った時の挙動に似せました)

unit_testの結果がfalseの部分がありますが，それは終了ステータスとエラーメッセージの修正によるものです.