### PR TITLE
Rnakai/refactor unit test and fix bug of auto resize cpy

### DIFF
--- a/src/parse/utils/auto_resize_cpy.c
+++ b/src/parse/utils/auto_resize_cpy.c
@@ -25,7 +25,7 @@ char		*auto_resize_cpy(char *dst, int idx, int *buf_size, char src_ch)
 		dst[idx] = src_ch;
 			return (dst);
 	}
-	while (idx >= *buf_size)
+	while (idx >= *buf_size - 2)
 		*buf_size += RESIZE_BUF_LEN;
 	resized_dst = ft_calloc(sizeof(char), *buf_size);
 	if (resized_dst == NULL)

--- a/test/cfiles/test_parse/test_expand_env.c
+++ b/test/cfiles/test_parse/test_expand_env.c
@@ -128,6 +128,7 @@ int		main(void)
 #include "parse.h"
 #include <stdio.h>
 #include "libft.h"
+#include <string.h>
 
 static void leak_test_func1(void)
 {
@@ -136,7 +137,7 @@ static void leak_test_func1(void)
 	int		buf_size;
 
 	buf_size = 10;
-	dst = malloc(sizeof(char) * buf_size);
+	dst = ft_calloc(sizeof(char), buf_size);
 	for (int i = 0; src[i]; i++)
 		dst = auto_resize_cpy(dst, i, &buf_size, src[i]);
 	ft_putendl_fd(dst, 1);
@@ -150,10 +151,38 @@ static void leak_test_func2(void)
 	int		buf_size;
 
 	buf_size = 10;
-	dst = malloc(sizeof(char) * buf_size);
+	dst = ft_calloc(sizeof(char), buf_size);
 	for (int i = 0; src[i]; i++)
 		dst = auto_resize_cpy(dst, i, &buf_size, src[i]);
 	ft_putendl_fd(dst, 1);
+	free(dst);
+}
+
+void	leak_test_func3()
+{
+	char *src;
+	char *dst;
+	int		bufsize = 10;
+	int		idx = 0;
+	dst = ft_calloc(sizeof(char*), bufsize);
+	src = ft_calloc(sizeof(char*), 20000);
+	for (int i = 0; i < 10000; i++)
+	{
+		if (i % 10 == 0)
+		{
+			src[idx] = '\n';
+			dst[idx] = '\n';
+			idx++;
+		}
+		src[idx] = (i % 10) + '0';
+		dst = auto_resize_cpy(dst, idx, &bufsize, (i % 10) + '0');
+		idx++;
+	}
+	if (strcmp(src, dst))
+		printf("cpy failed\n");
+	// ft_putstr_fd(src, 1);
+	// ft_putstr_fd(dst, 2);
+	free(src);
 	free(dst);
 }
 
@@ -161,6 +190,7 @@ int		main(void)
 {
 	leak_test_func1();
 	leak_test_func2();
+	leak_test_func3();
 }
 
 #endif

--- a/test/cfiles/test_parse/test_redirect.c
+++ b/test/cfiles/test_parse/test_redirect.c
@@ -17,18 +17,15 @@ static void	test_open(char *str, t_redir_mode *redir_mode)
 	char buf[1000];
 	t_process redir_config;
 	char	*fname_expanded;
-	char	*filename;
 	
 	fname_expanded = ft_strdup(str);
-	filename = ft_strdup(str);
 	ft_bzero(&redir_config, sizeof(t_process));
-	update_redir_config(&redir_config, filename, redir_mode);
+	update_redir_config(&redir_config, fname_expanded, redir_mode);
 	if (open_redir_file(str, &redir_config, redir_mode) == ERROR)
 		p_open_err(NULL, NULL, fname_expanded, &redir_config);
 	else
 	{
 		free(fname_expanded);
-		free(filename);
 		sprintf(buf, "cat %s", str);
 		system(buf);
 		wait(NULL);

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -13,7 +13,7 @@ function test_unit() {
 	echo "$1"
 	echo #改行
 	touch_all
-	make -s debug ARG=$1
+	make -s debug ARG=$1 sanitize=1
 
 	echo "---output test result---"
 	./minishell > ./test/latest/result/$1 2>&1
@@ -34,7 +34,10 @@ function test_unit() {
 	# else
 	# 	printf "${ESC}[31m%s${ESC}[m\n" 'FAILURE'
 	# fi
-	valgrind ./minishell > ./test/latest/memleak_log/$1 2>&1
+
+
+	# valgrind ./minishell > ./test/latest/memleak_log/$1 2>&1
+
 
 	echo "==================================="
 }


### PR DESCRIPTION
valgrindで毎度テスト結果を出力していましたが、結局人力確認になって効率が悪いので、
簡易版になりますが、gcc sanitizerを使ってリークの検査をする方式に変更しました。

これによって発覚したエラーケースやリークなどを修正しリファクタリングしました。


・dstのバッファサイズを気にせずコピーできるutil関数のauto_resize_cpyですが、
sanitizeで検査するとおかしな文字が出力されたので修正しました。
bufsizeを更新する条件にミスがあったので修正しました。

auto_resize_cpyですが、あらためて10万文字で検査しても大丈夫だったので、
おそらく動作に問題ないといえると思います。（時間がかかるのでテストケースでは１万文字検査にしています）

・open_redir_fileに、以前のテストケースで使用していたと思われる余分な文字列がstrdupで確保されていたので削除しました。