### PR TITLE
mallocエラーが起きたらすぐにexitするように修正

### DIFF
--- a/include/builtins/my_cd.h
+++ b/include/builtins/my_cd.h
@@ -1,7 +1,7 @@
 #ifndef MY_CD_H
 # define MY_CD_H
 
-int		change_env_vars(void);
+void	change_env_vars(void);
 void	put_error_msg(char *file_path);
 
 #endif

--- a/include/builtins/my_export.h
+++ b/include/builtins/my_export.h
@@ -3,7 +3,7 @@
 
 #include "struct/env_list.h"
 
-int			sort_keys_by_lexical_order(char **env_str_arr);
+void		sort_keys_by_lexical_order(char **env_str_arr);
 char 		*create_env_str(t_env_list *env_node);
 int			print_env_at_my_export(void);
 t_env_list	**create_new_env_nodes_arr(char **args, int *exit_status);

--- a/src/builtins/my_cd/change_env_vars.c
+++ b/src/builtins/my_cd/change_env_vars.c
@@ -12,7 +12,7 @@
 extern char			*g_pwd;
 extern t_env_list	*g_env_list;
 
-static int	set_env_pwd(char **args_for_my_export)
+static void	set_env_pwd(char **args_for_my_export)
 {
 	char	*pwd;
 
@@ -20,50 +20,37 @@ static int	set_env_pwd(char **args_for_my_export)
 	{
 		put_error_msg(NULL);
 		if (!(pwd = ft_strjoin(g_pwd, "/.")))
-			return (ERROR);
+			exit(malloc_error());
 	}
 	if (!(args_for_my_export[1] = ft_strjoin("PWD=", pwd)))
-	{
-		free_string_arr(args_for_my_export);
-		return (ERROR);
-	}
+		exit(malloc_error());
 	free(pwd);
-	return (SUCCESS);
 }
 
-static int	set_env_old_pwd(char **args_for_my_export)
+static void	set_env_old_pwd(char **args_for_my_export)
 {
 	t_env_list	*pwd_node;
 
 	if ((pwd_node = search_env_node("PWD")) != g_env_list)
 	{
 		if (!(args_for_my_export[2] = ft_strjoin("OLDPWD=", pwd_node->value)))
-			return (ERROR);
+			exit(malloc_error());
 	}
 	else
 		args_for_my_export[2] = NULL;
-	return (SUCCESS);
 }
 
-int			change_env_vars(void)
+void		change_env_vars(void)
 {
 	char		**args_for_my_export;
 
 	if (!(args_for_my_export = malloc(sizeof(char *) * 4)))
-		return (ERROR);
+		exit(malloc_error());
 	if (!(args_for_my_export[0] = ft_strdup("export")))
-	{
-		free_string_arr(args_for_my_export);
-		return (ERROR);
-	}
-	if (set_env_pwd(args_for_my_export) == ERROR
-	|| set_env_old_pwd(args_for_my_export) == ERROR)
-	{
-		free_string_arr(args_for_my_export);
-		return (ERROR);
-	}
+		exit(malloc_error());
+	set_env_pwd(args_for_my_export);
+	set_env_old_pwd(args_for_my_export);
 	args_for_my_export[3] = NULL;
 	my_export(args_for_my_export);
 	free_string_arr(args_for_my_export);
-	return (SUCCESS);
 }

--- a/src/builtins/my_cd/my_cd.c
+++ b/src/builtins/my_cd/my_cd.c
@@ -21,12 +21,12 @@ static char		*replace_homedir_with_path(char *arg)
 	if (!arg)
 	{
 		if (!(path = ft_strdup(homedir_path)))
-			return (NULL);
+			exit(malloc_error());
 	}
 	else
 	{
 		if (!(path = ft_strjoin(homedir_path, &arg[1])))
-			return (NULL);
+			exit(malloc_error());
 	}
 	return (path);
 }
@@ -36,14 +36,11 @@ static char		*set_path(char *arg)
 	char	*path;
 
 	if (!arg || arg[0] == '~')
-	{
-		if (!(path = replace_homedir_with_path(arg)))
-			return (NULL);
-	}
+		path = replace_homedir_with_path(arg);
 	else
 	{
 		if (!(path = ft_strdup(arg)))
-			return (NULL);
+			exit(malloc_error());
 	}
 	return (path);
 }
@@ -70,8 +67,7 @@ int				my_cd(char **args)
 
 	if (!is_valid_arg(args))
 		return (GENERAL_ERRORS);
-	if (!(path = set_path(args[1])))
-		return (malloc_error());
+	path = set_path(args[1]);
 	if (chdir(path) == -1)
 	{
 		put_error_msg(path);
@@ -79,10 +75,9 @@ int				my_cd(char **args)
 		return (GENERAL_ERRORS);
 	}
 	free(path);
-	if (change_env_vars() == ERROR)
-		return (malloc_error());
+	change_env_vars();
 	if (!(new_pwd = ft_strdup(search_env_node("PWD")->value)))
-		return (malloc_error());
+		exit(malloc_error());
 	free(g_pwd);
 	g_pwd = new_pwd;
 	return (SUCCEEDED);

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -9,6 +9,13 @@
 
 extern volatile sig_atomic_t g_status;
 
+static void		put_numeric_argument_error(char *arg)
+{
+	ft_putstr_fd("minishell: exit: ", STD_ERR);
+	ft_putstr_fd(arg, STD_ERR);
+	ft_putendl_fd(": numeric argument required", STD_ERR);
+}
+
 static t_bool	is_numeric_argument(char *arg)
 {
 	int	i;
@@ -46,9 +53,7 @@ int				my_exit(char **args)
 		}
 		if (!is_numeric_argument(args[i]))
 		{
-			ft_putstr_fd("minishell: exit: ", STD_ERR);
-			ft_putstr_fd(args[i], STD_ERR);
-			ft_putendl_fd(": numeric argument required", STD_ERR);
+			put_numeric_argument_error(args[i]);
 			exit(MISUSE_OF_SHELL_BUILTINS);
 		}
 		++i;

--- a/src/builtins/my_exit/my_exit.c
+++ b/src/builtins/my_exit/my_exit.c
@@ -49,12 +49,13 @@ int				my_exit(char **args)
 			ft_putstr_fd("minishell: exit: ", STD_ERR);
 			ft_putstr_fd(args[i], STD_ERR);
 			ft_putendl_fd(": numeric argument required", STD_ERR);
-			g_status = MISUSE_OF_SHELL_BUILTINS;
 			exit(MISUSE_OF_SHELL_BUILTINS);
 		}
 		++i;
 	}
+	if (!args[1])
+		exit(SUCCEEDED);
 	if (args[1])
-		g_status = ft_atol(args[1]) & 255;
-	exit(g_status);
+		exit(ft_atol(args[1]) & 255);
+	return (SUCCEEDED);
 }

--- a/src/builtins/my_export/create_env_str.c
+++ b/src/builtins/my_export/create_env_str.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "libft.h"
+#include "utils.h"
 #include "struct/env_list.h"
 
 static int	count_bk_slsh_should_insert(char *value)
@@ -24,7 +25,7 @@ static char	*insert_back_slash(char *value)
 	if (!(value_inserted_bk_slsh =
 	malloc(sizeof(char) *
 	(ft_strlen(value) + count_bk_slsh_should_insert(value) + 1))))
-		return (NULL);
+		exit(malloc_error());
 	i = 0;
 	while (*value)
 	{
@@ -49,16 +50,15 @@ static char	*create_tmp_env_str(char *env_str, t_env_list *env_node)
 	if (ft_strchr(env_node->value, '\\') || ft_strchr(env_node->value, '$')
 	|| ft_strchr(env_node->value, '\"'))
 	{
-		if (!(value_inserted_bk_slsh = insert_back_slash(env_node->value)))
-			return (NULL);
+		value_inserted_bk_slsh = insert_back_slash(env_node->value);
 		if (!(tmp = ft_strjoin(env_str, value_inserted_bk_slsh)))
-			return (NULL);
+			exit(malloc_error());
 		free(value_inserted_bk_slsh);
 	}
 	else
 	{
 		if (!(tmp = ft_strjoin(env_str, env_node->value)))
-			return (NULL);
+			exit(malloc_error());
 	}
 	return (tmp);
 }
@@ -69,16 +69,18 @@ char		*create_env_str(t_env_list *env_node)
 	char	*tmp;
 
 	if (!(env_node->value))
-		env_str = ft_strdup(env_node->key);
+	{
+		if (!(env_str = ft_strdup(env_node->key)))
+			exit(malloc_error());
+	}
 	else
 	{
 		if (!(env_str = ft_strjoin(env_node->key, "=\"")))
-			return (NULL);
-		if (!(tmp = create_tmp_env_str(env_str, env_node)))
-			return (NULL);
+			exit(malloc_error());
+		tmp = create_tmp_env_str(env_str, env_node);
 		free(env_str);
 		if (!(env_str = ft_strjoin(tmp, "\"")))
-			return (NULL);
+			exit(malloc_error());
 		free(tmp);
 	}
 	return (env_str);

--- a/src/builtins/my_export/create_new_env_nodes_arr.c
+++ b/src/builtins/my_export/create_new_env_nodes_arr.c
@@ -15,7 +15,7 @@ t_env_list	**create_new_env_nodes_arr(char **args, int *exit_status)
 
 	if (!(new_env_nodes =
 	malloc(sizeof(t_env_list *) * (count_string_arr_row(args)))))
-		return (NULL);
+		exit(malloc_error());
 	i = 0;
 	while (args[i + 1])
 	{

--- a/src/builtins/my_export/my_export.c
+++ b/src/builtins/my_export/my_export.c
@@ -18,8 +18,7 @@ int	my_export(char **args)
 		exit_status = print_env_at_my_export();
 	else
 	{
-		if (!(new_env_nodes = create_new_env_nodes_arr(args, &exit_status)))
-			return (malloc_error());
+		new_env_nodes = create_new_env_nodes_arr(args, &exit_status);
 		i = 0;
 		while (new_env_nodes[i])
 		{

--- a/src/builtins/my_export/print_env_at_my_export.c
+++ b/src/builtins/my_export/print_env_at_my_export.c
@@ -36,13 +36,12 @@ static char	**create_env_str_arr_from_env_list(int node_count)
 	i = 0;
 	env_node = g_env_list->next;
 	if (!(env_str_arr = malloc(sizeof(char *) * (node_count + 1))))
-		return (NULL);
+		exit(malloc_error());
 	while (i < node_count)
 	{
 		if (ft_strcmp(env_node->key, "_"))
 		{
-			if (!(env_str_arr[i] = create_env_str(env_node)))
-				return (NULL);
+			env_str_arr[i] = create_env_str(env_node);
 			++i;
 		}
 		env_node = env_node->next;
@@ -56,10 +55,8 @@ int			print_env_at_my_export(void)
 	int		i;
 	char	**env_str_arr;
 
-	if (!(env_str_arr = create_env_str_arr_from_env_list(count_env_node())))
-		return (malloc_error());
-	if (sort_keys_by_lexical_order(env_str_arr) < 0)
-		return (malloc_error());
+	env_str_arr = create_env_str_arr_from_env_list(count_env_node());
+	sort_keys_by_lexical_order(env_str_arr);
 	i = 0;
 	while (env_str_arr[i])
 	{

--- a/src/builtins/my_export/sort_keys_by_lexical_order.c
+++ b/src/builtins/my_export/sort_keys_by_lexical_order.c
@@ -15,16 +15,16 @@ static int	comapre_keys(char *env1, char *env2)
 	if (!(env2_eq_ptr = ft_strchr(env2, '=')))
 		env2_eq_ptr = env2 + ft_strlen(env2);
 	if (!(env1_key = ft_substr(env1, 0, (size_t)(env1_eq_ptr - env1))))
-		return (1024);
+		exit(malloc_error());
 	if (!(env2_key = ft_substr(env2, 0, (size_t)(env2_eq_ptr - env2))))
-		return (1024);
+		exit(malloc_error());
 	cmp_result = ft_strcmp(env1_key, env2_key);
 	free(env1_key);
 	free(env2_key);
 	return (cmp_result);
 }
 
-int			sort_keys_by_lexical_order(char **env_str_arr)
+void			sort_keys_by_lexical_order(char **env_str_arr)
 {
 	int		i;
 	int		j;
@@ -38,8 +38,6 @@ int			sort_keys_by_lexical_order(char **env_str_arr)
 		while (env_str_arr[j])
 		{
 			cmp_result = comapre_keys(env_str_arr[j - 1], env_str_arr[j]);
-			if (cmp_result == 1024)
-				return (-1);
 			if (0 < cmp_result)
 			{
 				tmp = env_str_arr[j - 1];
@@ -50,5 +48,4 @@ int			sort_keys_by_lexical_order(char **env_str_arr)
 		}
 		++i;
 	}
-	return (0);
 }

--- a/src/env/create_env_list.c
+++ b/src/env/create_env_list.c
@@ -11,18 +11,14 @@
 extern volatile sig_atomic_t g_status;
 extern t_env_list	*g_env_list;
 
-static int	init_env_list(void)
+static void	init_env_list(void)
 {
 	if (!(g_env_list = malloc(sizeof(t_env_list))))
-	{
-		malloc_error();
-		return (ERROR);
-	}
+		exit(malloc_error());
 	g_env_list->key = NULL;
 	g_env_list->value = NULL;
 	g_env_list->prev = g_env_list;
 	g_env_list->next = g_env_list;
-	return (SUCCESS);
 }
 
 int			create_env_list(char **envp)
@@ -31,16 +27,11 @@ int			create_env_list(char **envp)
 	t_env_list	*new;
 
 	i = 0;
-	if (init_env_list() == ERROR)
-		return (ERROR);
+	init_env_list();
 	while (envp[i])
 	{
 		if (!(new = make_new_env_node(envp[i])))
-		{
-			g_status = malloc_error();
 			return (ERROR);
-			// exit(GENERAL_ERRORS);
-		}
 		new->next = g_env_list;
 		g_env_list->prev->next = new;
 		new->prev = g_env_list->prev;

--- a/src/env/get_env_array.c
+++ b/src/env/get_env_array.c
@@ -29,22 +29,16 @@ static char	*make_env_str(t_env_list *env_var)
 	char	*env_var_str;
 
 	if (!(tmp = ft_strjoin(env_var->key, "=")))
-		return (NULL);
+		exit(malloc_error());
 	if (env_var->value)
 	{
 		if (!(env_var_str = ft_strjoin(tmp, env_var->value)))
-		{
-			free(tmp);
-			return (NULL);
-		}
+			exit(malloc_error());
 	}
 	else
 	{
 		if (!(env_var_str = ft_strdup(tmp)))
-		{
-			free(tmp);
-			return (NULL);
-		}
+			exit(malloc_error());
 	}
 	free(tmp);
 	return (env_var_str);
@@ -57,17 +51,12 @@ char		**get_env_array(void)
 	t_env_list	*env_var;
 
 	if (!(env = malloc(sizeof(char *) * (count_env_list() + 1))))
-		return (NULL);
+		exit(malloc_error());
 	i = 0;
 	env_var = g_env_list->next;
 	while (env_var->key)
 	{
-		if (!(env[i] = make_env_str(env_var)))
-		{
-			free_string_arr(env);
-			g_status = malloc_error();
-			return (NULL);
-		}
+		env[i] = make_env_str(env_var);
 		++i;
 		env_var = env_var->next;
 	}

--- a/src/env/get_path_array.c
+++ b/src/env/get_path_array.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "libft.h"
 #include "utils.h"
 #include "struct/env_list.h"
@@ -24,9 +25,6 @@ char	**get_path_array(void)
 	if (tmp == g_env_list)
 		return (NULL);
 	if (!(path = ft_split(tmp->value, ':')))
-	{
-		g_status = malloc_error();
-		return (NULL);
-	}
+		exit(malloc_error());
 	return (path);
 }

--- a/src/env/make_new_env_node.c
+++ b/src/env/make_new_env_node.c
@@ -6,35 +6,33 @@
 #include "struct/t_bool.h"
 #include "struct/env_list.h"
 
-static int	set_new_env_value(char *replica_of_arg, t_env_list *new)
+static void	set_new_env_value(char *replica_of_arg, t_env_list *new)
 {
 	char	*equal_ptr;
 
 	if ((equal_ptr = ft_strchr(replica_of_arg, '=')))
 	{
 		if (!(new->value = ft_strdup(equal_ptr + 1)))
-			return (ERROR);
+			exit(malloc_error());
 	}
 	else
 		new->value = NULL;
-	return (SUCCESS);
 }
 
-static int	set_new_env_key(char *arg, t_env_list *new)
+static void	set_new_env_key(char *arg, t_env_list *new)
 {
 	char	*equal_ptr;
 
 	if ((equal_ptr = ft_strchr(arg, '=')))
 	{
 		if (!(new->key = ft_substr(arg, 0, (size_t)(equal_ptr - arg))))
-			return (ERROR);
+			exit(malloc_error());
 	}
 	else
 	{
 		if (!(new->key = ft_strdup(arg)))
-			return (ERROR);
+			exit(malloc_error());
 	}
-	return (SUCCESS);
 }
 
 t_env_list	*make_new_env_node(char *arg)
@@ -42,17 +40,9 @@ t_env_list	*make_new_env_node(char *arg)
 	t_env_list	*new;
 
 	if (!(new = malloc(sizeof(t_env_list))))
-		return (NULL);
-	if (set_new_env_key(arg, new) == ERROR)
-	{
-		free(new);
-		return (NULL);
-	}
-	if (set_new_env_value(arg, new) == ERROR)
-	{
-		free_env_node(new);
-		return (NULL);
-	}
+		exit(malloc_error());
+	set_new_env_key(arg, new);
+	set_new_env_value(arg, new);
 	if (!is_valid_env_key(new->key))
 	{
 		free_env_node(new);

--- a/src/execute/exec_cmds.c
+++ b/src/execute/exec_cmds.c
@@ -40,10 +40,7 @@ static void	exec_cmd(int i, int **pipe_fd, t_process *procs)
 	close_and_dup_fds_in_child_proc(i, pipe_fd, procs);
 	close_and_dup_fds_to_redirect(&(procs[i]));
 	if (!(procs[i].cmd[0]))
-	{
-		g_status = SUCCEEDED;
-		exit(g_status);
-	}
+		exit(SUCCEEDED);
 	if (!(procs[i].cmd[0][0]))
 		if_command_not_found(procs[i].cmd[0]);
 	if (is_builtin_func(procs[i].cmd[0]))
@@ -52,10 +49,7 @@ static void	exec_cmd(int i, int **pipe_fd, t_process *procs)
 		exit(g_status);
 	}
 	if (!(envp = get_env_array()))
-	{
-		g_status = malloc_error();
-		exit(g_status);
-	}
+		exit(malloc_error());
 	my_execve(procs[i].cmd, envp);
 }
 

--- a/src/execute/join_cmd_to_path.c
+++ b/src/execute/join_cmd_to_path.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "libft.h"
+#include "utils.h"
 
 char	*join_cmd_to_path(char *cmd, char *path_ptr)
 {
@@ -10,14 +11,14 @@ char	*join_cmd_to_path(char *cmd, char *path_ptr)
 	if (path_ptr[ft_strlen(path_ptr) - 1] != '/')
 	{
 		if (!(add_slash = ft_strjoin(path_ptr, "/")))
-			return (NULL);
+			exit(malloc_error());
 		if (!(cmd_path = ft_strjoin(add_slash, cmd)))
-			return (NULL);
+			exit(malloc_error());
 	}
 	else
 	{
 		if (!(cmd_path = ft_strjoin(path_ptr, cmd)))
-			return (NULL);
+			exit(malloc_error());
 	}
 	free(add_slash);
 	return (cmd_path);

--- a/src/execute/my_execve.c
+++ b/src/execute/my_execve.c
@@ -37,18 +37,11 @@ static char	*get_command_path(char *cmd)
 	char	**path_db_ptr;
 
 	if (!(path_db_ptr = get_path_array()))
-	{
-		g_status = malloc_error();
 		return (NULL);
-	}
 	i = 0;
 	while (path_db_ptr[i])
 	{
-		if (!(cmd_path = join_cmd_to_path(cmd, path_db_ptr[i])))
-		{
-			g_status = malloc_error();
-			return (NULL);
-		}
+		cmd_path = join_cmd_to_path(cmd, path_db_ptr[i]);
 		if (is_there_execute_file_at(cmd_path))
 			return (cmd_path);
 		free(cmd_path);

--- a/src/execute/pipe_fd_array.c
+++ b/src/execute/pipe_fd_array.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include "utils.h"
 #include "execute.h"
 #include "struct/process.h"
 
@@ -11,11 +12,11 @@ int		**create_pipe_fd_array(t_process *procs)
 	i = 0;
 	num_of_procs = count_procs(procs);
 	if (!(pipe_fd = malloc(sizeof(int *) * num_of_procs)))
-		return (NULL);
+		exit(malloc_error());
 	while (i < num_of_procs)
 	{
 		if (!(pipe_fd[i] = malloc(sizeof(int) * 2)))
-			return (NULL);
+			exit(malloc_error());
 		++i;
 	}
 	return (pipe_fd);


### PR DESCRIPTION
今まではmallocエラーが起きたらNULLやERRORを返したりしていましたが，その場でexit(malloc_error())するようにしました．
それによって関数の返り値が変わったものもあります．

以下の関数でエラーが起きたらexitするようにしました
- malloc
- ft_strdup
- ft_strjoin
- ft_substr
- ft_split