### PR TITLE
Rnakai/modify calloc lib to exit after failing malloc

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -7,11 +7,8 @@
 
 # define DIVIDER -3
 
-#ifndef DEBUG  //後で削除。デバッグ用で値をいじれるように
-# define RESIZE_BUF_LEN 1000 
-#endif
-
-# define BUF_LEN 1000
+# define RESIZE_BUF_LEN 200 
+# define BUF_LEN 200
 
 char		***convert_line2tasks(char *line);
 void		replace_meta_with_divider(char *line, char rplced_ch);

--- a/lib/libft/ft_calloc.c
+++ b/lib/libft/ft_calloc.c
@@ -6,13 +6,19 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/07/02 17:11:35 by rnakai            #+#    #+#             */
-/*   Updated: 2020/07/02 17:27:04 by rnakai           ###   ########.fr       */
+/*   Updated: 2021/03/03 12:35:09 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stddef.h>
 #include <stdlib.h>
 #include "libft.h"
+
+static int	memalloc_error(void)
+{
+	ft_putendl_fd("minishell: malloc error", 2);
+	return (2);
+}
 
 void		*ft_calloc(size_t nmemb, size_t size)
 {
@@ -21,7 +27,7 @@ void		*ft_calloc(size_t nmemb, size_t size)
 	ptr = (void *)malloc(nmemb * size);
 	if (ptr == NULL)
 	{
-		return (ptr);
+		exit(memalloc_error());
 	}
 	ft_bzero(ptr, nmemb * size);
 	return (ptr);

--- a/lib/libft/ft_split.c
+++ b/lib/libft/ft_split.c
@@ -6,7 +6,7 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/07/07 11:01:41 by rnakai            #+#    #+#             */
-/*   Updated: 2020/08/05 16:57:08 by rnakai           ###   ########.fr       */
+/*   Updated: 2021/03/03 12:42:18 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,7 +101,7 @@ char		**ft_split(char const *str, char ch)
 	if (!(trimmed_str = ft_strtrim(str, divider)))
 		return (NULL);
 	words = count_words(trimmed_str, ch);
-	if (!(ret_db_ptr = (char **)malloc(sizeof(char *) * (words + 1))))
+	if (!(ret_db_ptr = (char **)ft_calloc(sizeof(char *), (words + 1))))
 	{
 		free(trimmed_str);
 		return (NULL);

--- a/lib/libft/ft_strdup.c
+++ b/lib/libft/ft_strdup.c
@@ -6,12 +6,11 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/07/02 17:47:07 by rnakai            #+#    #+#             */
-/*   Updated: 2020/07/02 17:55:16 by rnakai           ###   ########.fr       */
+/*   Updated: 2021/03/03 12:39:17 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
-#include <stdlib.h>
 
 char		*ft_strdup(const char *str)
 {
@@ -19,7 +18,7 @@ char		*ft_strdup(const char *str)
 	size_t	strsize;
 
 	strsize = ft_strlen(str);
-	ptr = (char *)malloc((strsize + 1) * sizeof(char));
+	ptr = (char *)ft_calloc((strsize + 1), sizeof(char));
 	if (ptr == NULL)
 	{
 		return (NULL);

--- a/lib/libft/ft_substr.c
+++ b/lib/libft/ft_substr.c
@@ -6,7 +6,7 @@
 /*   By: rnakai <rnakai@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/07/05 12:48:19 by rnakai            #+#    #+#             */
-/*   Updated: 2020/07/11 12:44:45 by rnakai           ###   ########.fr       */
+/*   Updated: 2021/03/03 12:32:46 by rnakai           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ char		*ft_substr(char const *s, unsigned int start, size_t len)
 		return ((char *)ft_calloc(1, sizeof(char)));
 	if (s_size < len + start)
 		len = s_size - start;
-	ptr = (char *)malloc(sizeof(char) * (len + 1));
+	ptr = (char *)ft_calloc(sizeof(char), len + 1);
 	if (ptr == NULL)
 		return (NULL);
 	idx = 0;

--- a/src/execute/exec_tasks.c
+++ b/src/execute/exec_tasks.c
@@ -70,12 +70,7 @@ void			exec_tasks(char ***tasks)
 	i = 0;
 	while (tasks[i]) //行のループ
 	{
-		if (!(procs = parse_each_task(tasks[i])))
-		{
-			g_status = malloc_error();
-			++i;
-			continue;
-		}
+		procs = parse_each_task(tasks[i]);
 		if (should_exec_builtin_func(procs))
 			exec_single_process_builtin(&procs[0]);
 		else

--- a/src/parse/convert/convert_line2tasks.c
+++ b/src/parse/convert/convert_line2tasks.c
@@ -23,8 +23,7 @@ char		***convert_line2tasks(char *line)
 
 	cut_last_endl(line);
 	replace_meta_with_divider(line, ';');
-	semicolon_splitted = ft_split(line, DIVIDER); //should free TODO: error処理
-	//ここでプロセス行数がわかるので、行数分+1 malloc
+	semicolon_splitted = ft_split(line, DIVIDER);
 	tasks = (char***)ft_calloc(sizeof(char**),
 		(count_string_arr_row(semicolon_splitted) + 1)); //TODO:error処理
 	i = 0;

--- a/src/parse/cut_all_cmds_modifier.c
+++ b/src/parse/cut_all_cmds_modifier.c
@@ -8,8 +8,6 @@ char		**cut_all_cmds_modifier(char **raw_cmds)
 	int		i;
 
 	cmds = ft_calloc(sizeof(char**), count_string_arr_row(raw_cmds) + 1);
-	if (cmds == NULL)
-		return (NULL);
 	i = 0;
 	while (raw_cmds[i])
 	{

--- a/src/parse/parse_each_task.c
+++ b/src/parse/parse_each_task.c
@@ -42,8 +42,6 @@ t_process			*parse_each_task(char **str_procs)
 
 	proc_num = count_string_arr_row(str_procs);
 	procs = ft_calloc(sizeof(t_process), proc_num + 1); //TODO:
-	if (procs == NULL)
-		return (NULL);
 	procs[proc_num].is_end = TRUE;
 	i = 0;
 	while (str_procs[i])

--- a/src/parse/utils/auto_resize_cpy.c
+++ b/src/parse/utils/auto_resize_cpy.c
@@ -3,10 +3,6 @@
 #include "utils.h"
 #include <stdlib.h>
 
-# ifdef DEBUG //後で消す
-# define RESIZE_BUF_LEN 10
-# endif
-
 /*
 ** dst = auto_resize_cpy(dst, i, buf_size, src[i]);
 ** このようにして、dstの容量を気にせずにイテレートしてコピーし続けられる。
@@ -28,11 +24,6 @@ char		*auto_resize_cpy(char *dst, int idx, int *buf_size, char src_ch)
 	while (idx >= *buf_size - 2)
 		*buf_size += RESIZE_BUF_LEN;
 	resized_dst = ft_calloc(sizeof(char), *buf_size);
-	if (resized_dst == NULL)
-	{
-		ft_perror(NULL);
-		return (NULL); //TODO:これが起きたらセグフォする
-	}
 	i = 0;
 	while (dst[i])
 	{

--- a/src/parse/utils/cut_modifier.c
+++ b/src/parse/utils/cut_modifier.c
@@ -65,8 +65,6 @@ char		*cut_modifier(char *src)
 	int		i_dst;
 
 	dst = ft_calloc(sizeof(char*), ft_strlen(src));
-	if (dst == NULL)
-		return (NULL);
 	i_dst = 0;
 	i_src = 0; 
 	while (src[i_src])


### PR DESCRIPTION
libftのcallocを独自に変更し、mallocが失敗したときexitするようにしました。
自分の場合はmallocは使っておらず、すべてcallocでメモリ確保しているので特にエラー処理を親関数に入れずに
mallocが失敗時のリスクをケアできるようになっています。

また、ft_strdup, split, substrではmallocを使っていたので、callocに書き直しました。

ライブラリの変更があったので、  make fcleanコマンドを使用してください。

### その他
auto_resize_cpyでデバッグ用に使っていた定数を削除し、本番用の値で統一しました。
