### PR TITLE
Yyabumot/create my exit at child process

### DIFF
--- a/include/builtins/builtins.h
+++ b/include/builtins/builtins.h
@@ -8,6 +8,7 @@ int my_unset(char **args);
 int my_env(char **args); 
 int my_pwd(char **args);
 int my_exit(char **args);
+int	my_exit_at_child_process(char **args);
 int	redir_fail_cmd(char **args);
 void exec_builtins(char **args);
 

--- a/include/builtins/my_exit.h
+++ b/include/builtins/my_exit.h
@@ -3,5 +3,6 @@
 
 long int ft_atol(const char *str);
 int my_exit(char **args);
+int		my_exit_at_child_process(char **args);
 
 #endif

--- a/src/builtins/my_exit/my_exit_at_child_process.c
+++ b/src/builtins/my_exit/my_exit_at_child_process.c
@@ -1,0 +1,64 @@
+#include <stdlib.h>
+#include "libft.h"
+#include "utils.h"
+#include "constants.h"
+#include "exit_status.h"
+#include "struct/t_bool.h"
+#include "builtins/my_exit.h"
+#include <signal.h>
+
+extern volatile sig_atomic_t g_status;
+
+static void		put_numeric_argument_error(char *arg)
+{
+	ft_putstr_fd("minishell: exit: ", STD_ERR);
+	ft_putstr_fd(arg, STD_ERR);
+	ft_putendl_fd(": numeric argument required", STD_ERR);
+}
+
+static t_bool	is_numeric_argument(char *arg)
+{
+	int	i;
+	int digit;
+
+	i = 0;
+	digit = 0;
+	if (arg[i] == '-' || arg[i] == '+')
+		++i;
+	while (arg[i])
+	{
+		if (arg[i] < '0' || '9' < arg[i])
+			return (FALSE);
+		++digit;
+		++i;
+	}
+	if (20 <= digit)
+		return (FALSE);
+	return (TRUE);
+}
+
+int				my_exit_at_child_process(char **args)
+{
+	int	i;
+
+	i = 1;
+	while (args[i])
+	{
+		if (1 < i)
+		{
+			ft_putendl_fd("minishell: exit: too many arguments", STD_ERR);
+			exit(GENERAL_ERRORS);
+		}
+		if (!is_numeric_argument(args[i]))
+		{
+			put_numeric_argument_error(args[i]);
+			exit(MISUSE_OF_SHELL_BUILTINS);
+		}
+		++i;
+	}
+	if (!args[1])
+		exit(SUCCEEDED);
+	if (args[1])
+		exit(ft_atol(args[1]) & 255);
+	return (SUCCEEDED);
+}

--- a/src/execute/exec_cmds.c
+++ b/src/execute/exec_cmds.c
@@ -43,6 +43,8 @@ static void	exec_cmd(int i, int **pipe_fd, t_process *procs)
 		exit(SUCCEEDED);
 	if (!(procs[i].cmd[0][0]))
 		if_command_not_found(procs[i].cmd[0]);
+	if (!ft_strcmp(procs[i].cmd[0], "exit"))
+		my_exit_at_child_process(procs[i].cmd);
 	if (is_builtin_func(procs[i].cmd[0]))
 	{
 		exec_builtins(procs[i].cmd);


### PR DESCRIPTION
exitがパイプでつながれたときに使うmy_exit_at_child_process関数を実装しました

my_exitと違う点
- "exit"を標準エラー出力しない
- 複数引数エラーの時GENERAL_ERRORSでプロセスを終了する