### PR TITLE
Rnakai/add validation of terminating with backslash

### DIFF
--- a/include/validation.h
+++ b/include/validation.h
@@ -13,5 +13,6 @@ t_bool	is_valid_redirect(char **cmd_line, t_bool *is_redirect);
 t_bool	is_valid_meta_and_redirect(char *cmd_line);
 t_bool is_valid_quote(char *cmd_line);
 t_bool is_valid_command_line(char *cmd_line);
+t_bool	is_cmd_line_terminated_with_bkslsh(char *cmd_line);
 
 #endif

--- a/src/validation/is_cmd_line_terminated_with_bkslsh.c
+++ b/src/validation/is_cmd_line_terminated_with_bkslsh.c
@@ -1,0 +1,26 @@
+#include "struct/t_bool.h"
+#include "constants.h"
+#include "validation.h"
+
+t_bool	is_cmd_line_terminated_with_bkslsh(char *cmd_line)
+{
+	int		i;
+
+	i = 0;
+	while (cmd_line[i])
+	{
+		if (cmd_line[i] == BACK_SLASH)
+		{
+			if (cmd_line[i + 1] == '\n')
+			{
+				put_syntax_error_message(
+					"terminating with backslash is forbidden.");
+				return (TRUE);
+			}
+			i += 2;
+			continue ;
+		}
+		i++;
+	}
+	return (FALSE);
+}

--- a/src/validation/is_valid_command_line.c
+++ b/src/validation/is_valid_command_line.c
@@ -1,8 +1,34 @@
 #include "validation.h"
 #include "struct/t_bool.h"
+#include "constants.h"
+
+static t_bool	is_cmd_line_terminated_with_bkslsh(char *cmd_line)
+{
+	int		i;
+
+	i = 0;
+	while (cmd_line[i])
+	{
+		if (cmd_line[i] == BACK_SLASH)
+		{
+			if (cmd_line[i + 1] == '\n')
+			{
+				put_syntax_error_message(
+					"terminating with backslash is forbidden.");
+				return (TRUE);
+			}
+			i += 2;
+			continue ;
+		}
+		i++;
+	}
+	return (FALSE);
+}
 
 t_bool	is_valid_command_line(char *cmd_line)
 {
+	if (is_cmd_line_terminated_with_bkslsh(cmd_line))
+		return (FALSE);
 	if (!is_valid_char_code(cmd_line))
 		return (FALSE);
 	if (!is_valid_meta_and_redirect(cmd_line))

--- a/src/validation/is_valid_command_line.c
+++ b/src/validation/is_valid_command_line.c
@@ -2,29 +2,6 @@
 #include "struct/t_bool.h"
 #include "constants.h"
 
-static t_bool	is_cmd_line_terminated_with_bkslsh(char *cmd_line)
-{
-	int		i;
-
-	i = 0;
-	while (cmd_line[i])
-	{
-		if (cmd_line[i] == BACK_SLASH)
-		{
-			if (cmd_line[i + 1] == '\n')
-			{
-				put_syntax_error_message(
-					"terminating with backslash is forbidden.");
-				return (TRUE);
-			}
-			i += 2;
-			continue ;
-		}
-		i++;
-	}
-	return (FALSE);
-}
-
 t_bool	is_valid_command_line(char *cmd_line)
 {
 	if (is_cmd_line_terminated_with_bkslsh(cmd_line))

--- a/test/answer/result/IS_CMD_LINE_TERMINATED_WITH_BKSLSH_C
+++ b/test/answer/result/IS_CMD_LINE_TERMINATED_WITH_BKSLSH_C
@@ -1,0 +1,22 @@
+Valid commands ==========
+[32mVALID[m : echo \\
+
+[32mVALID[m : \\
+
+
+Invalid commands ========
+minishell: syntax error terminating with backslash is forbidden.
+[31mINVALID[m : \
+
+minishell: syntax error terminating with backslash is forbidden.
+[31mINVALID[m : \\\
+
+minishell: syntax error terminating with backslash is forbidden.
+[31mINVALID[m : \\\\\
+
+minishell: syntax error terminating with backslash is forbidden.
+[31mINVALID[m : echo \
+
+minishell: syntax error terminating with backslash is forbidden.
+[31mINVALID[m : echo\a \\\
+

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -101,11 +101,6 @@ int main(void)
 		"echo \'a\\\'\' ", //   'a\''
 		"echo \"a",
 		"echo \"\\", //この例だとセグフォする可能性がある
-		"\\",
-		"\\\\\\",
-		"\\\\\\\\\\",
-		"echo \\",
-		"echo\\a \\\\\\",
 	};
 
 	ft_putstr_fd("Valid commands ==========\n", STD_OUT);

--- a/test/cfiles/test_validation.c
+++ b/test/cfiles/test_validation.c
@@ -1,3 +1,52 @@
+#ifdef IS_CMD_LINE_TERMINATED_WITH_BKSLSH_C
+
+#include <stdlib.h>
+#include "libft.h"
+#include "validation.h"
+#include "constants.h"
+#include "struct/t_bool.h"
+
+static void test_backslash(char *cmd_line)
+{
+	t_bool ret_bool;
+
+	ret_bool = is_cmd_line_terminated_with_bkslsh(cmd_line);
+	if(ret_bool == TRUE)
+		ft_putstr_fd("\x1b[31mINVALID\x1b[m", STD_OUT);
+	else
+		ft_putstr_fd("\x1b[32mVALID\x1b[m", STD_OUT);
+	ft_putstr_fd(" : ", STD_OUT);
+	ft_putendl_fd(cmd_line, STD_OUT);
+}
+
+int main(void)
+{
+	char *valid_cmds[] =
+	{
+		"echo \\\\\n",
+		"\\\\\n",
+	};
+
+	char *invalid_cmds[] =
+	{
+		"\\\n",
+		"\\\\\\\n",
+		"\\\\\\\\\\\n",
+		"echo \\\n",
+		"echo\\a \\\\\\\n",
+	};
+
+	ft_putstr_fd("Valid commands ==========\n", STD_OUT);
+	for(size_t i = 0; i < sizeof(valid_cmds) / sizeof(char *); ++i)
+		test_backslash(valid_cmds[i]);
+
+	ft_putstr_fd("\nInvalid commands ========\n", STD_OUT);
+	for(size_t i = 0; i < sizeof(invalid_cmds) / sizeof(char *); ++i)
+		test_backslash(invalid_cmds[i]);
+}
+
+#endif
+
 #ifdef IS_VALID_QUOTE_C
 
 #include <stdlib.h>
@@ -52,6 +101,11 @@ int main(void)
 		"echo \'a\\\'\' ", //   'a\''
 		"echo \"a",
 		"echo \"\\", //この例だとセグフォする可能性がある
+		"\\",
+		"\\\\\\",
+		"\\\\\\\\\\",
+		"echo \\",
+		"echo\\a \\\\\\",
 	};
 
 	ft_putstr_fd("Valid commands ==========\n", STD_OUT);

--- a/test/update_result.sh
+++ b/test/update_result.sh
@@ -56,3 +56,4 @@ function update_each_file() {
 # update_each_file IS_VALID_QUOTE_C
 # update_each_file IS_VALID_CHAR_CODE_C
 # update_each_file IS_VALID_META_AND_REDIRECT_C
+# update_each_file IS_CMD_LINE_TERMINATED_WITH_BKSLSH_C

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -76,5 +76,6 @@ test_unit CUT_MODIFIER_C
 test_unit IS_VALID_QUOTE_C
 test_unit IS_VALID_CHAR_CODE_C
 test_unit IS_VALID_META_AND_REDIRECT_C
+test_unit IS_CMD_LINE_TERMINATED_WITH_BKSLSH_C
 
 # test_unit PARSE_EACH_TASK_C #不完全なテストなのでまだ追加しない


### PR DESCRIPTION
自分でも作ってみました。
このケースだと
まず文字列にバックスラッシュが含まれるか判定

バックスラッシュの次の文字が改行文字であればバックスラッシュ終端している

バックスラッシュは基本的に 2 インクリメントし、バックスラッシュ直後の文字は判定しないようにする

それ以外の文字はすべて1ずつインクリメントして判定

バックスラッシュ終端を判定する関数を分離しユニットテストも追加しました。

※※
d2c628d
で間違えてIS_VALID_QUOTEの方に新しいテストを加えてしまったので、
c123222
で記述を削除しました。